### PR TITLE
Use `management/find` instead of `cluster/find`

### DIFF
--- a/pkg/rancher-ai-ui/pages/settings/Settings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/Settings.vue
@@ -70,7 +70,7 @@ const activeChatbotOptions = [
 ];
 
 const resource = useFetch(async() => {
-  return await store.dispatch(`cluster/find`, {
+  return await store.dispatch(`management/find`, {
     type: 'secret',
     id:   'cattle-ai-agent-system/llm-config',
     opt:  { watch: true }


### PR DESCRIPTION
`cluster` will prefer the previously active cluster. `management` will always target local.