### PR TITLE
Remove cluster from context based on current route

### DIFF
--- a/pkg/rancher-ai-ui/store/context.ts
+++ b/pkg/rancher-ai-ui/store/context.ts
@@ -27,8 +27,9 @@ const getters = {
 
     // Get current cluster from the store
     const currentCluster = rootGetters['currentCluster'];
+    const currentPath = rootState?.targetRoute?.path || '';
 
-    const activeCluster = currentCluster ? [{
+    const activeCluster = currentCluster && currentPath.includes(`/c/${ currentCluster.name }`) ? [{
       tag:         ContextTag.CLUSTER,
       value:       currentCluster.name,
       valueLabel:  currentCluster.nameDisplay || currentCluster.name,


### PR DESCRIPTION
- When navigating from cluster explorer to home, the `rootGetters['currentCluster']` in the store still keeps the old cluster name, so it remains in the Chat context. Comparing it with the current path is the easiest way to remove the cluster from the context store ATM.