### PR TITLE
Redeploy `rancher-ai-agent` after saving settings

### DIFF
--- a/pkg/rancher-ai-ui/pages/settings/types.ts
+++ b/pkg/rancher-ai-ui/pages/settings/types.ts
@@ -26,3 +26,17 @@ export interface FormData {
   [Settings.SYSTEM_PROMPT]?: string;
   [Settings.ACTIVE_CHATBOT]?: string;
 }
+
+export interface Workload {
+  nameDisplay: string;
+  type: string;
+  schema?: any;
+  spec: {
+    template: {
+      metadata?: {
+        annotations?: Record<string, string>;
+      };
+    };
+  };
+  save: () => Promise<void>;
+}


### PR DESCRIPTION
This redeploys the `rancher-ai-agent` deployment after saving settings. 

We want to restart the pod from when making changes to the secret so that `llm-settings` can be easily loaded by the agent pod.