### PR TITLE
Update styles for code blocks in chat messages

### DIFF
--- a/pkg/rancher-ai-ui/components/message/index.vue
+++ b/pkg/rancher-ai-ui/components/message/index.vue
@@ -291,6 +291,7 @@ onBeforeUnmount(() => {
   box-shadow: 0 2px 8px 0 rgba(0,0,0,0.04);
   padding: 12px;
   font-size: 0.95rem;
+  line-height: 21px;
   display: flex;
   flex-direction: column;
   gap: 6px;


### PR DESCRIPTION
This updates the styles for code blocks in chat messages. The line height of text in chat messages is also updated.

## Details

This addresses the following comments:

- For inline `<code>` blocks (and only for the inline `<code>` blocks), we need to get rid of the paddings, backgrounds, borders, etc.
- Keep the monospaced font and change the text colour to another colour (green?)
- The line-height used in bubbles  (both user and assistant bubbles) however is something we really must fix - increase it to 21px please

We currently don't implement the following: 

- the user can interact with (e.g. on hover I get the copy-to-clipboard icon that lets me copy the code)

I think that we will require a larger change to get this. We have this feature elsewhere, but it's implemented specifically for the `KeyValueRow` component. 

## Screenshots

<img width="1378" height="1159" alt="image" src="https://github.com/user-attachments/assets/77ff3c3b-3107-42c9-ae3e-214d8d4fb2b9" />

<img width="1378" height="1159" alt="image" src="https://github.com/user-attachments/assets/0063ecbe-aa37-486b-a481-5c883b47ca2a" />
