### PR TITLE
Update shortcut to `alt+k`

### DIFF
--- a/pkg/rancher-ai-ui/index.ts
+++ b/pkg/rancher-ai-ui/index.ts
@@ -55,8 +55,8 @@ export default function(plugin: IPlugin, { store }: any): void {
     {
       tooltipKey: 'ai.action.openChat',
       shortcut: { 
-        windows: ['alt', 'shift', 'k'], 
-        mac: ['alt', 'shift', 'k'] 
+        windows: ['alt', 'k'], 
+        mac: ['alt', 'k'] 
       },
       icon: 'icon-ai',
       invoke: () => {


### PR DESCRIPTION
This updates the shortcut to `alt+k`.

We will need to update dashboard to properly translate alt to ⌥. 