### PR TITLE
Fix related resource routing in multi-cluster env

### DIFF
--- a/pkg/rancher-ai-ui/components/message/action/RelatedResource.vue
+++ b/pkg/rancher-ai-ui/components/message/action/RelatedResource.vue
@@ -19,7 +19,15 @@ const to = ref<any>(null);
 const tooltip = ref<string>('');
 
 function goTo() {
-  store.state.$router.push(to.value.detailLocation);
+  if (to.value.detailLocation) {
+    store.state.$router.push({
+      ...to.value.detailLocation,
+      params: {
+        ...(to.value.detailLocation.params || {}),
+        cluster: props.value?.resource?.cluster || to.value.detailLocation.params?.cluster, // Preserve cluster param
+      }
+    });
+  }
 }
 
 onMounted(async() => {


### PR DESCRIPTION
- Related Resources crash when navigating to another cluster and clicking on 1 of them. The `detailLocation` of the resource contains the wrong cluster's reference - It has to be the origin cluster.

Before

[Screencast from 2025-11-03 17-30-29.webm](https://github.com/user-attachments/assets/6b8e89cd-2103-48fe-9067-df5a845ecc13)

After

[Screencast from 2025-11-03 17-32-01.webm](https://github.com/user-attachments/assets/047f493b-a956-4b1e-aa46-a11ea8030c8a)


