### PR TITLE
Rename 'Recommended Actions' to 'Quick Actions'

### DIFF
--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -40,7 +40,7 @@ ai:
       showCompleteMessage: See More
       hideCompleteMessage: See Less
     suggestions:
-      label: Recommended Actions
+      label: Quick Actions
     template:
       heyAnalyzeResource: 'Hey Liz, please analyse the resource'
       namespace: 'Namespace'


### PR DESCRIPTION
This resolves a line item that discusses potential problems surrounding the usage of "recommended". 