### PR TITLE
Disable model dropdown when no selections can be made

### DIFF
--- a/pkg/rancher-ai-ui/pages/settings/Settings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/Settings.vue
@@ -305,6 +305,7 @@ const save = async(btnCB: (arg: boolean) => void) => { // eslint-disable-line no
 
       <div class="form-field">
         <labeled-select
+          :disabled="modelOptions.length <= 1"
           :value="formData[Settings.MODEL]"
           :label="t(`aiConfig.form.${ Settings.MODEL}.label`)"
           :options="modelOptions"


### PR DESCRIPTION
This disables the model dropdown if there are no options to select in the list.

closes rancher/dashboard#15833