### PR TITLE
Check Agent permissions

### DIFF
--- a/pkg/rancher-ai-ui/components/message/action/Action.vue
+++ b/pkg/rancher-ai-ui/components/message/action/Action.vue
@@ -3,15 +3,15 @@ import { onMounted, ref, type PropType } from 'vue';
 import { useStore } from 'vuex';
 import { warn } from '../../../utils/log';
 import RcButton from '@components/RcButton/RcButton.vue';
-import { MessageActionRelatedResource } from '../../../types';
+import { MessageAction } from '../../../types';
 import { ActionType } from '../../../types';
 
 const store = useStore();
 
 const props = defineProps({
   value: {
-    type:    Object as PropType<MessageActionRelatedResource>,
-    default: () => ({} as MessageActionRelatedResource),
+    type:    Object as PropType<MessageAction>,
+    default: () => ({} as MessageAction),
   }
 });
 
@@ -27,7 +27,7 @@ function goTo() {
         /**
          * TODO:
          * We are assuming that the product is 'explorer' here because
-         * RelatedResource actions are only for resources that exist in the cluster explorer, at this time.
+         * Resource actions are only for resources that exist in the cluster explorer, at this time.
          *
          * 1. The productId should be dynamic and based on where the resource is located, ex: Fleet -> get Gitrepos
          */
@@ -55,7 +55,7 @@ onMounted(async() => {
         id: namespace ? `${ namespace }/${ name }` : name
       });
     } catch (e) {
-      warn('RelatedResource - Could not find related resource', e);
+      warn('Action - Could not find resource', e);
       to.value = null;
     }
   }

--- a/pkg/rancher-ai-ui/components/message/action/index.vue
+++ b/pkg/rancher-ai-ui/components/message/action/index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { MessageActionRelatedResource } from '../../../types';
+import { MessageAction } from '../../../types';
 import { computed, type PropType, ref } from 'vue';
 import { useStore } from 'vuex';
-import RelatedResource from './RelatedResource.vue';
+import Action from './Action.vue';
 
 const THRESHOLD = 7; // Maximum number of actions for human readability
 
@@ -10,9 +10,13 @@ const store = useStore();
 const t = store.getters['i18n/t'];
 
 const props = defineProps({
+  label: {
+    type:    String,
+    default: '',
+  },
   actions: {
-    type:    Array as PropType<MessageActionRelatedResource[]>,
-    default: () => ([] as MessageActionRelatedResource[]),
+    type:    Array as PropType<MessageAction[]>,
+    default: () => ([] as MessageAction[]),
   },
 });
 
@@ -42,7 +46,7 @@ const toggleRemaining = () => {
 <template>
   <div class="chat-actions-container">
     <div class="chat-msg-action-title">
-      <span>{{ t('ai.message.relatedResources.label') }}</span>
+      <span>{{ props.label || 'ACTIONS' }}</span>
     </div>
     <div class="chat-msg-actions-container">
       <div class="chat-msg-action-tags">
@@ -51,7 +55,7 @@ const toggleRemaining = () => {
           :key="index"
           class="mt-2 chat-msg-actions"
         >
-          <RelatedResource :value="action" />
+          <Action :value="action" />
         </div>
         <template v-if="showRemaining">
           <div
@@ -59,7 +63,7 @@ const toggleRemaining = () => {
             :key="index"
             class="mt-2 chat-msg-actions"
           >
-            <RelatedResource :value="action" />
+            <Action :value="action" />
           </div>
         </template>
       </div>
@@ -69,10 +73,10 @@ const toggleRemaining = () => {
         @click="toggleRemaining"
       >
         <template v-if="!showRemaining">
-          {{ t('ai.message.relatedResources.more', { count: remaining.length }, true) }}
+          {{ t('ai.message.actions.more', { count: remaining.length }, true) }}
         </template>
         <template v-else>
-          {{ t('ai.message.relatedResources.less', {}, true) }}
+          {{ t('ai.message.actions.less', {}, true) }}
         </template>
         <i
           class="icon icon-sm"

--- a/pkg/rancher-ai-ui/components/message/index.vue
+++ b/pkg/rancher-ai-ui/components/message/index.vue
@@ -249,7 +249,17 @@ onBeforeUnmount(() => {
         class="chat-msg-section"
       >
         <Actions
+          :label="t('ai.message.relatedResourcesActions.label')"
           :actions="props.message.relatedResourcesActions"
+        />
+      </div>
+      <div
+        v-if="props.message.actions?.length"
+        class="chat-msg-section"
+      >
+        <Actions
+          :label="t('ai.message.quickActions.label')"
+          :actions="props.message.actions"
         />
       </div>
       <div

--- a/pkg/rancher-ai-ui/composables/useAgentComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useAgentComposable.ts
@@ -48,7 +48,9 @@ export function useAgentComposable() {
   }
 
   async function checkAgentAvailability() {
-    if (store.getters['management/schemaFor'](WORKLOAD_TYPES.DEPLOYMENT)) {
+    if (!store.getters['management/canList'](WORKLOAD_TYPES.DEPLOYMENT)) {
+      error.value = { key: 'ai.error.agent.deployment.noPermission' };
+    } else {
       try {
         const agent = await store.dispatch('management/find', {
           type: WORKLOAD_TYPES.DEPLOYMENT,
@@ -57,7 +59,7 @@ export function useAgentComposable() {
 
         if (agent && agent.state !== 'active') {
           error.value = {
-            key:    'ai.error.agent.notActive',
+            key:    'ai.error.agent.deployment.notActive',
             action: {
               label:    t('ai.agent.goToDeployment'),
               type:     ActionType.Button,
@@ -73,7 +75,7 @@ export function useAgentComposable() {
       } catch (e) {
         warn('\'rancher-ai-agent\' deployment not found', e);
         error.value = {
-          key:    'ai.error.agent.notFound',
+          key:    'ai.error.agent.deployment.notFound',
           action: {
             label:    t('ai.agent.goToInstall'),
             type:     ActionType.Button,
@@ -81,14 +83,18 @@ export function useAgentComposable() {
           }
         };
       }
-    } else {
-      warn('Deployment schema not found');
     }
 
     return !error.value;
   }
 
   async function getAgentConfigs() {
+    if (!store.getters['management/canList'](SECRET)) {
+      error.value = { key: 'ai.error.agent.secret.noPermission' };
+
+      return;
+    }
+
     try {
       const secret = await store.dispatch('management/find', {
         type:    SECRET,
@@ -104,7 +110,7 @@ export function useAgentComposable() {
 
     if (!agent.value) {
       error.value = {
-        key:    'ai.error.agent.missingConfig',
+        key:    'ai.error.agent.secret.missingConfig',
         action: {
           label:    t('ai.settings.goToSettings'),
           type:     ActionType.Button,

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -22,16 +22,17 @@ ai:
         inProgress: Thinking
     source:
       label: SOURCE
-    relatedResources:
+    relatedResourcesActions:
       label: RELATED RESOURCES
-      tooltip: '{kind}: {namespace}/{name} in {cluster} cluster'
+    quickActions:
+      label: QUICK ACTIONS
+    actions:
       more: |-
         {count, plural,
           =1 { and {count} more resource }
           other { and {count} more resources }
         }
       less: Show Less
-    actions:
       tooltip:
         copy: Copy to Clipboard
         resend: Resend Message
@@ -87,8 +88,8 @@ ai:
       openai: ChatGPT
       gemini: Gemini
     unknown: Unknown Agent
-    goToInstall: Install Agent
-    goToDeployment: View Deployment
+    goToInstall: View Charts
+    goToDeployment: View Agent Deployment
   hooks:
     menu:
       header:
@@ -110,7 +111,7 @@ ai:
         label: Ask Liz
   settings:
     title: AI Assistant
-    goToSettings: Settings
+    goToSettings: Configure AI Assistant
   confirmation:
     message:
       question: Are you sure you want to proceed with this action?
@@ -141,9 +142,13 @@ ai:
       connection: Failed to connect to Rancher AI Agent. Please try again later.
       disconnected: Connection closed.
     agent:
-      notFound: Rancher AI Agent not found. Please ensure the agent chart is installed.
-      notActive: Rancher AI Agent is not active. Please ensure the agent is running properly.
-      missingConfig: Rancher AI Agent configuration is missing. Please go to Global [Settings > AI Assistant] and configure the agent.
+      secret:
+        noPermission: You do not have permission to access the Rancher AI Agent configuration. Please contact your administrator.
+        missingConfig: Rancher AI Agent configuration is missing. Please go to Global [Settings > AI Assistant] and configure the agent.
+      deployment:
+        noPermission: You do not have permission to access the Rancher AI Agent. Please contact your administrator.
+        notFound: Rancher AI Agent not found. Please ensure the agent chart is installed.
+        notActive: Rancher AI Agent is not active. Please ensure the agent is running properly.
   options:
     chat:
       reset:

--- a/pkg/rancher-ai-ui/types.ts
+++ b/pkg/rancher-ai-ui/types.ts
@@ -3,7 +3,7 @@
 export interface ChatError {
   key?:     string;
   message?: string;
-  action?:  MessageActionRelatedResource;
+  action?:  MessageAction;
 }
 
 export interface ConnectionError extends ChatError {
@@ -90,7 +90,7 @@ export interface MessageConfirmationAction {
   resource: ActionResource;
 }
 
-export interface MessageActionRelatedResource {
+export interface MessageAction {
   type: ActionType | string;
   label: string;
   tooltip?: string;
@@ -129,7 +129,8 @@ export interface Message {
   completed?: boolean;
   showThinking?: boolean;
   showCompleteMessage?: boolean;
-  relatedResourcesActions?: MessageActionRelatedResource[];
+  actions?: MessageAction[];
+  relatedResourcesActions?: MessageAction[];
   suggestionActions?: string[];
   confirmation?: MessageConfirmation;
   source?: object;

--- a/pkg/rancher-ai-ui/utils/format.ts
+++ b/pkg/rancher-ai-ui/utils/format.ts
@@ -3,7 +3,7 @@ import {
   ActionType, MessageConfirmationAction, Tag, Context,
   Message,
   Role,
-  MessageActionRelatedResource
+  MessageAction
 } from '../types';
 import { validateActionResource } from './validator';
 
@@ -33,7 +33,7 @@ export function formatMessagePromptWithContext(prompt: string, selectedContext: 
   });
 }
 
-export function formatMessageRelatedResourcesActions(value: string, actionType = ActionType.Button): MessageActionRelatedResource[] {
+export function formatMessageRelatedResourcesActions(value: string, actionType = ActionType.Button): MessageAction[] {
   value = value.replaceAll(Tag.McpResultStart, '').replaceAll(Tag.McpResultEnd, '').replace(/'([^']*)'/g, '"');
 
   if (value) {


### PR DESCRIPTION
- Adding `canList` guard when fetching the Agent deployment and Agent secret

<img width="501" height="380" alt="image" src="https://github.com/user-attachments/assets/1d338483-ca7e-4204-9e9e-f994ee803993" />


- Adding quick Actions to the message body and re-enabling actions on error messages (found regression)

<img width="634" height="550" alt="image" src="https://github.com/user-attachments/assets/f239f80b-1b7e-49f0-a984-b5bb81928aee" />

<img width="634" height="550" alt="image" src="https://github.com/user-attachments/assets/9ca968da-79c6-4426-a1ab-b5f16b5f3865" />

