### PR TITLE
Update condition for rendering privacy notice banner

### DIFF
--- a/pkg/rancher-ai-ui/pages/settings/Settings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/Settings.vue
@@ -280,7 +280,7 @@ const save = async(btnCB: (arg: boolean) => void) => { // eslint-disable-line no
         @update:model-value="(val: string | undefined) => updateValue(Settings.ACTIVE_CHATBOT, val as ChatBotEnum)"
       />
       <banner
-        v-if="formData[Settings.ACTIVE_CHATBOT] !== 'Local'"
+        v-if="formData[Settings.ACTIVE_CHATBOT] !== ChatBotEnum.Local"
         color="warning"
         class="mt-0 mb-0"
       >


### PR DESCRIPTION
The privacy notice banner is using an outdated value to conditionally render. This updates it so that it uses the enum instead of the string "Local".