### PR TITLE
Update macOS keyboard shortcut

### DIFF
--- a/pkg/rancher-ai-ui/index.ts
+++ b/pkg/rancher-ai-ui/index.ts
@@ -56,7 +56,7 @@ export default function(plugin: IPlugin, { store }: any): void {
       tooltipKey: 'ai.action.openChat',
       shortcut: { 
         windows: ['alt', 'k'], 
-        mac: ['alt', 'k'] 
+        mac: ['meta', 'shift', 'k'] 
       },
       icon: 'icon-ai',
       invoke: () => {


### PR DESCRIPTION
This updates the macOS keyboard shortcut to `meta+shift+K`. 

It turns out that the option key isn't supported in `vue-shortkey`[^1]. Instead of keeping the keyboard shortcuts consistent between platforms, I think it's best to implement shortcuts that are platform specific. 

I tested `meta+shift+K` in both FF & Chrome on macOS and did not encounter any conflicts with existing browser shortcuts.  

[^1]: https://github.com/fgr-araujo/vue-shortkey/issues/28