### PR TITLE
Load management schemas before building the related resources buttons

### DIFF
--- a/pkg/rancher-ai-ui/components/message/action/Action.vue
+++ b/pkg/rancher-ai-ui/components/message/action/Action.vue
@@ -42,11 +42,13 @@ onMounted(async() => {
   if (!!props.value.resource.detailLocation) {
     to.value = props.value.resource;
   } else {
+    const inStore = 'management';
+
+    await store.dispatch('loadManagement');
+
     const {
       cluster, type, namespace, name
     } = props.value.resource;
-
-    const inStore = store.getters['currentProduct'].inStore || 'management';
 
     try {
       to.value = await store.dispatch(`${ inStore }/find`, {


### PR DESCRIPTION
The related resources buttons are disabled if the UI didn't load the schemas first. 
For example: the Chat is operating in the Home page.

Before

[Screencast from 2025-11-20 12-24-46.webm](https://github.com/user-attachments/assets/74f058ff-49b4-4976-b4a7-7035625212ed)

After

[Screencast from 2025-11-20 12-24-05.webm](https://github.com/user-attachments/assets/905160fc-e4ae-4398-812d-e59e9ec29ce5)

