### PR TITLE
Fix history messages - summary field

### DIFF
--- a/cypress/e2e/tests/features/hooks.spec.ts
+++ b/cypress/e2e/tests/features/hooks.spec.ts
@@ -47,10 +47,12 @@ describe('Hooks', () => {
       chatItem.showTooltip();
 
       chatItem.tooltip().within(() => {
-        // The tooltip content should be: Summary + Content + Created at information
+        // The tooltip content should be: Summary + CreatedAt
         cy.contains('Please analyse the Cluster "local" and troubleshoot any problems.').should('be.visible');
-        cy.contains('Explain what the "active" state means').should('be.visible');
         cy.contains('Started on').should('be.visible');
+
+        // The message body should not be visible
+        cy.contains('Explain what the "active" state means').should('not.exist');
       });
     });
   });

--- a/pkg/rancher-ai-ui/components/message/index.vue
+++ b/pkg/rancher-ai-ui/components/message/index.vue
@@ -496,7 +496,7 @@ onBeforeUnmount(() => {
 .chat-msg-selected-agent-label {
   color: #BFC1D3;
   font-family: Lato;
-  font-size: 12px;
+  font-size: 14px;
   font-style: normal;
   font-weight: 400;
   line-height: 21px; /* 150% */

--- a/pkg/rancher-ai-ui/components/panels/History.vue
+++ b/pkg/rancher-ai-ui/components/panels/History.vue
@@ -52,14 +52,8 @@ function chatNameTooltip(chat: HistoryChat): string {
     });
   }
 
-  let name = '';
-
-  if (chat.name) {
-    name = chat.name.replaceAll('\n', '<br>').slice(0, 500).trim();
-  }
-
   return t('ai.history.chat.items.nameTooltip', {
-    name,
+    name: chat.name,
     createdAt
   }, true);
 }

--- a/pkg/rancher-ai-ui/composables/useChatHistoryComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatHistoryComposable.ts
@@ -12,7 +12,12 @@ export function useChatHistoryComposable(agents: ComputedRef<Agent[]>) {
 
       const all = await data.json() as HistoryChat[];
 
-      return all.filter((chat) => !!chat.name);
+      return all
+        .filter((chat) => !!chat.name)
+        .map((chat) => ({
+          ...chat,
+          name: chat.name?.split('\n')[0].slice(0, 500).trim(),
+        }));
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to fetch chats:', error);

--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -10,7 +10,7 @@ import {
   ActionType,
   Agent,
   AgentSelectionMode,
-  ChatError, ConfirmationResponse, ConfirmationStatus, Message, MessagePhase, MessageTag, MessageTemplateComponent, Role, Tag
+  ChatError, ConfirmationResponse, ConfirmationStatus, Message, MessageLabelKey, MessagePhase, MessageTag, MessageTemplateComponent, Role, Tag
 } from '../types';
 import {
   formatWSInputMessage, formatMessageRelatedResourcesActions, formatConfirmationAction, formatSuggestionActions, formatFileMessages,
@@ -81,11 +81,17 @@ export function useChatMessageComposable(
     let summaryContent = '';
     let messageContent = msg as string;
     let contextContent = selectedContext.value;
+    let labels = undefined;
 
     // msg is type of Message
     if (msg && typeof msg === 'object' && msg.messageContent) {
       role = msg.role;
+
       summaryContent = msg.summaryContent || '';
+      if (summaryContent) {
+        labels = { [MessageLabelKey.Summary]: summaryContent };
+      }
+
       messageContent = msg.messageContent || '';
       contextContent = msg.contextContent || [];
     } else { /* msg is type of string */ }
@@ -94,6 +100,7 @@ export function useChatMessageComposable(
       prompt:  messageContent,
       context: selectedContext.value,
       agent:   agentName.value,
+      labels
     }));
 
     const agentMetadata = { agent: agents.value.find((a) => a.name === agentName.value) || {} as Agent };

--- a/pkg/rancher-ai-ui/handlers/hooks/overlay/badge-sliding.ts
+++ b/pkg/rancher-ai-ui/handlers/hooks/overlay/badge-sliding.ts
@@ -3,7 +3,7 @@ import { Store } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import { waitFor } from '@shell/utils/async';
 import { warn } from '../../../utils/log';
-import { Context } from '../../../types';
+import { Context, MessageLabelKey } from '../../../types';
 import { HooksOverlay } from './index';
 import Chat from '../../chat';
 import TemplateMessage from '../template-message';
@@ -251,15 +251,11 @@ class BadgeSlidingOverlay extends HooksOverlay {
       const ws = store.getters['rancher-ai-ui/connection/ws'];
 
       if (!!ws) {
-        let prompt = message.messageContent || '';
-
-        if (message.summaryContent) {
-          prompt = `${ message.summaryContent }\n\n${ prompt }`;
-        }
-
         ws.send(formatWSInputMessage({
-          prompt,
+          prompt:  message.messageContent || '',
           context: message.contextContent || [],
+          tags:    ['sliding-badge'],
+          labels:  { [MessageLabelKey.Summary]: message.summaryContent || '' }
         }));
       }
 

--- a/pkg/rancher-ai-ui/types.ts
+++ b/pkg/rancher-ai-ui/types.ts
@@ -181,6 +181,10 @@ export interface MessageTemplateContent {
   message: string;
 }
 
+export const enum MessageLabelKey {
+  Summary = 'summary',
+}
+
 export interface Message {
   id?: number | string;
   role: Role;
@@ -249,6 +253,7 @@ export interface HistoryChatMessage {
   }
   message: string;
   context?: string;
+  labels?: Record<MessageLabelKey, string>;
   tags?: string[];
   confirmation?: boolean;
   createdAt: string;

--- a/pkg/rancher-ai-ui/utils/format.ts
+++ b/pkg/rancher-ai-ui/utils/format.ts
@@ -10,6 +10,7 @@ import {
   AgentMetadata,
   AIAgentConfigCRD,
   Agent,
+  MessageLabelKey,
 } from '../types';
 import { validateActionResource } from './validator';
 
@@ -17,6 +18,7 @@ interface WSInputMessageArgs {
   prompt: string;
   agent?: string;
   context?: Context[];
+  labels?: Record<MessageLabelKey, string>;
   tags?: string[];
 }
 
@@ -46,6 +48,7 @@ export function formatWSInputMessage(args: WSInputMessageArgs): string {
     prompt: args.prompt,
     agent:  args.agent,
     context,
+    labels: args.labels,
     tags,
   });
 }
@@ -341,6 +344,11 @@ export function buildMessageFromHistoryMessage(msg: HistoryChatMessage, agents: 
     msg.message = remaining;
   }
 
+  /**
+   * Parsing summary content
+   */
+  const summaryContent = msg.labels?.[MessageLabelKey.Summary] || undefined;
+
   return {
     role:              msg.role === 'agent' ? Role.Assistant : Role.User,
     completed:         true,
@@ -349,6 +357,7 @@ export function buildMessageFromHistoryMessage(msg: HistoryChatMessage, agents: 
     agentMetadata,
     thinkingContent,
     contextContent,
+    summaryContent,
     relatedResourcesActions,
     confirmation,
     suggestionActions,


### PR DESCRIPTION
The agent is now able to store the summary in the the sliding badge's messages

- We are now sending the summary content as a separated field:

```
labels:  { [MessageLabelKey.Summary]: message.summaryContent || '' }
```

parsing it to build the history messages.

- We are also fixing some bits in the chat name & tooltip

[Screencast from 2026-02-10 12-23-37.webm](https://github.com/user-attachments/assets/efa1cf23-9215-4fc1-a5a2-7ec4cd1255aa)
