### PR TITLE
Fix ResizeObserver loop errors

### DIFF
--- a/pkg/rancher-ai-ui/handlers/hooks/overlay/badge-sliding.ts
+++ b/pkg/rancher-ai-ui/handlers/hooks/overlay/badge-sliding.ts
@@ -80,19 +80,27 @@ class BadgeSlidingOverlay extends HooksOverlay {
   private handleParentPositionChange(target: HTMLElement, container: HTMLElement, overlay: HTMLElement) {
     // destroy overlay if the container/parent moves (position changes)
     let lastContainerRect = container.getBoundingClientRect();
-    const onContainerPosChange = () => {
-      try {
-        const r = container.getBoundingClientRect();
+    let rafId: number | null = null;
 
-        if (r.top !== lastContainerRect.top || r.left !== lastContainerRect.left) {
-          // parent moved -> remove overlays for this target, immediately
-          this.destroy(target, true);
-        } else {
-          lastContainerRect = r;
-        }
-      } catch (e) {
-        warn('Error checking container position change', e);
+    const onContainerPosChange = () => {
+      // Debounce with RAF to avoid ResizeObserver loop errors
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
       }
+      rafId = requestAnimationFrame(() => {
+        try {
+          const r = container.getBoundingClientRect();
+
+          if (r.top !== lastContainerRect.top || r.left !== lastContainerRect.left) {
+            // parent moved -> remove overlays for this target, immediately
+            this.destroy(target, true);
+          } else {
+            lastContainerRect = r;
+          }
+        } catch (e) {
+          warn('Error checking container position change', e);
+        }
+      });
     };
 
     const containerRO = new ResizeObserver(onContainerPosChange);
@@ -112,6 +120,13 @@ class BadgeSlidingOverlay extends HooksOverlay {
 
     // attach cleanup so destroy() can call it (avoid leaks if overlay removed directly)
     (overlay as any).__parentPositionCleanup = () => {
+      try {
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId);
+        }
+      } catch (e) {
+        warn('Error canceling RAF', e);
+      }
       try {
         containerRO.disconnect();
       } catch (e) {


### PR DESCRIPTION
When opening the Chat and we are on Deployments page, the UI gets a `ResizeObserver loop completed with undelivered notifications` error.

<img width="890" height="270" alt="image" src="https://github.com/user-attachments/assets/8354d591-4071-4de0-8df0-2141323f688c" />


This is caused by the logic responsible for the sliding badges positions.

This change will fix it by cleaning-up the pending Animation Frames that handle the position of the status badges in the table.
The error is very random and hard to replicate, but we couldn't replicate it with this fix up, so we can just check that sliding badge behavior has no regressions for now.
