### PR TITLE
Fix console input, autofocus

### DIFF
--- a/pkg/rancher-ai-ui/components/panels/Console.vue
+++ b/pkg/rancher-ai-ui/components/panels/Console.vue
@@ -22,6 +22,10 @@ const store = useStore();
 const { t } = useI18n(store);
 
 const props = defineProps({
+  activeChatId: {
+    type:    String,
+    default: '',
+  },
   llmConfig: {
     type:     Object as PropType<LLMConfig | null>,
     default:  null,
@@ -105,18 +109,28 @@ function autoResizePrompt() {
   }
 }
 
-onMounted(() => {
-  nextTick(() => {
-    promptTextarea.value?.focus();
-    autoResizePrompt();
-  });
-});
-
 watch(() => text.value, () => {
   nextTick(() => {
     autoResizePrompt();
   });
 }, {});
+
+watch(
+  () => [props.disabled, props.activeChatId],
+  ([newDisabled, newChatId], [oldDisabled, oldChatId]) => {
+    if (!newDisabled && (oldDisabled || oldChatId !== newChatId)) {
+      nextTick(() => {
+        promptTextarea.value?.focus();
+      });
+    }
+  }
+);
+
+onMounted(() => {
+  nextTick(() => {
+    autoResizePrompt();
+  });
+});
 </script>
 
 <template>

--- a/pkg/rancher-ai-ui/components/popover/TextLabel.vue
+++ b/pkg/rancher-ai-ui/components/popover/TextLabel.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { defineProps } from 'vue';
 import {
   RcDropdown,
   RcDropdownTrigger,

--- a/pkg/rancher-ai-ui/pages/Chat.vue
+++ b/pkg/rancher-ai-ui/pages/Chat.vue
@@ -325,6 +325,7 @@ function unmount() {
         @select="selectContext"
       />
       <Console
+        :active-chat-id="chatMetadata.chatId"
         :llm-config="llmConfig"
         :agents="chatAgents"
         :agent-name="agentName"


### PR DESCRIPTION
This will fix the autofocus of the textarea in the Console panel.

We want to autofocus the input in the following scenarions:

- The chat is disconnected and reconnected
- Opening a new chat
- Resuming an old chat
- Selecting the Agent (already works)