### PR TITLE
Hide suggestions to avoid double confirmation actions

### DIFF
--- a/pkg/rancher-ai-ui/components/message/index.vue
+++ b/pkg/rancher-ai-ui/components/message/index.vue
@@ -189,7 +189,7 @@ onBeforeUnmount(() => {
           />
         </div>
         <div
-          v-if="props.message.suggestionActions?.length"
+          v-if="props.message.suggestionActions?.length && !pendingConfirmation"
           class="chat-msg-section-footer"
         >
           <Suggestions


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-ui/issues/160

When requesting multi-resource creation or update, it can happen that the second confirmation message contains quick actions that can lead into a new confirmation action.

We want to avoid this scenario and keep the confirmation workflow clean and simple: only 1 confirmation is allowed at a time.