### PR TITLE
Handle chat errors as System errors

### DIFF
--- a/cypress/e2e/tests/features/chat.spec.ts
+++ b/cypress/e2e/tests/features/chat.spec.ts
@@ -271,6 +271,40 @@ describe('Chat', () => {
       resultMessageAfterReconnection.isCompleted();
     });
 
+    it('it should support reconnections from no available agents condition (chat errors handling)', () => {
+      HomePagePo.goTo();
+
+      // Delete the mcp to make all built-in agents unavailable
+      cy.deleteRancherResource('v1', 'apps.deployment', `cattle-ai-agent-system/rancher-mcp-server`, false);
+
+      chat.open();
+
+      chat.isNotReady();
+      chat.getSystemErrorMessage(1).containsText('Failed to load MCP tools for all enabled agents.');
+      chat.getSystemErrorMessage(1).containsText('Please check the AI Agents configuration and ensure the MCP server is accessible with the provided connection details.');
+
+      // Re-install the chart, including the mcp, to make the agents available again and allow reconnection
+      cy.installRancherAIService({ waitForAIServiceReady: false });
+
+      chat.phase('Connecting').should('be.visible');
+
+      chat.isReady(20000);
+      chat.phase('Connecting').should('not.exist');
+
+      // Check that the chat is working after reconnection
+      chat.sendMessage('User request after reconnection');
+
+      const userMessageAfterReconnection = chat.getMessage(2);
+
+      userMessageAfterReconnection.containsText('User request after reconnection');
+
+      const resultMessageAfterReconnection = chat.getMessage(3);
+
+      resultMessageAfterReconnection.containsText('Mock service');
+
+      resultMessageAfterReconnection.isCompleted();
+    });
+
     after(() => {
       cy.installRancherAIService();
     });

--- a/cypress/e2e/tests/features/multi-agent/chat.spec.ts
+++ b/cypress/e2e/tests/features/multi-agent/chat.spec.ts
@@ -188,8 +188,8 @@ describe('Multi Agent Chat', () => {
 
     chat.open();
 
-    chat.getErrorMessage(1).containsText('Failed to load MCP tools for all enabled agents.');
-    chat.getErrorMessage(1).containsText('Please check the AI Agents configuration and ensure the MCP server is accessible with the provided connection details.');
+    chat.getSystemErrorMessage(1).containsText('Failed to load MCP tools for all enabled agents.');
+    chat.getSystemErrorMessage(1).containsText('Please check the AI Agents configuration and ensure the MCP server is accessible with the provided connection details.');
   });
 
   after(() => {

--- a/pkg/rancher-ai-ui/components/agent/SelectAgent.vue
+++ b/pkg/rancher-ai-ui/components/agent/SelectAgent.vue
@@ -3,7 +3,7 @@ import { debounce } from 'lodash';
 import { computed, ref, type PropType } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
-import { Agent } from '../../types';
+import { Agent, AgentState } from '../../types';
 import {
   RcDropdown,
   RcDropdownTrigger,
@@ -42,7 +42,7 @@ const props = defineProps({
 
 const emit = defineEmits(['select']);
 
-const activeAgentNames = computed(() => props.agents.filter((agent) => agent.status === 'active').map((agent) => agent.name));
+const activeAgentNames = computed(() => props.agents.filter((agent) => agent.status === AgentState.Active).map((agent) => agent.name));
 
 const options = computed<AgentOption[]>(() => {
   const defaultOptions = activeAgentNames.value.length > 1 ? [
@@ -59,8 +59,8 @@ const options = computed<AgentOption[]>(() => {
     ...props.agents.map((agent) => ({
       name:        agent.name,
       displayName: agent.displayName || agent.name,
-      error:       agent.status !== 'active',
-      tooltip:     agent.status !== 'active' ? t('ai.agents.items.unavailable', {}, true) : (agent.description || ''),
+      error:       agent.status !== AgentState.Active,
+      tooltip:     agent.status !== AgentState.Active ? t('ai.agents.items.unavailable', {}, true) : (agent.description || ''),
     }))
   ];
 });

--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -3,12 +3,22 @@ import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import { NORMAN } from '@shell/config/types';
 import { PRODUCT_NAME } from '../product';
-import { useContextComposable } from './useContextComposable';
 import {
   ActionType,
   Agent,
   AgentSelectionMode,
-  ChatError, ConfirmationResponse, ConfirmationStatus, Message, MessageInternalSource, MessageLabelKey, MessagePhase, MessageTag, MessageTemplateComponent, Role, Tag
+  ChatError,
+  ChatMetadata,
+  ConfirmationResponse,
+  ConfirmationStatus,
+  Message,
+  MessageInternalSource,
+  MessageLabelKey,
+  MessagePhase,
+  MessageTag,
+  MessageTemplateComponent,
+  Role,
+  Tag
 } from '../types';
 import {
   formatWSInputMessage, formatMessageRelatedResourcesActions, formatConfirmationActions, formatSuggestionActions, formatFileMessages,
@@ -18,6 +28,7 @@ import {
   formatChatErrorMessage
 } from '../utils/format';
 import { downloadFile } from '@shell/utils/download';
+import { useContextComposable } from './useContextComposable';
 
 const EXPAND_THINKING = false;
 const DISMISS_RECOMMENDED_AGENT_KEY = 'dismissed-agent-recommendation';
@@ -49,7 +60,8 @@ export function useChatMessageComposable(
   const currentMsg = ref<Message>({} as Message);
   const error = computed(() => store.getters['rancher-ai-ui/chat/error'](chatId));
 
-  const isChatInitialized = computed(() => !!store.getters['rancher-ai-ui/chat/metadata']?.chatId);
+  const chatMetadata = computed<ChatMetadata>(() => store.getters['rancher-ai-ui/chat/metadata'] || {});
+  const isChatInitialized = computed(() => !!chatMetadata.value.chatId);
 
   const phase = computed(() => store.getters['rancher-ai-ui/chat/phase'](chatId) || MessagePhase.Initializing);
 
@@ -276,7 +288,17 @@ export function useChatMessageComposable(
         processChatErrors(data);
         processChatMetadata(data);
       } catch (err) {
-        processInitErrorData(err as Error);
+        setErrors({
+          message: (err as Error)?.message || t('ai.error.chat.generic'),
+          action:  {
+            label:    t('ai.settings.goToSettings'),
+            type:     ActionType.Button,
+            resource: {
+              cluster:        'local',
+              detailLocation: { name: `c-cluster-settings-${ PRODUCT_NAME }` }
+            }
+          },
+        });
       }
     } else {
       try {
@@ -480,24 +502,6 @@ export function useChatMessageComposable(
     });
   }
 
-  function processInitErrorData(error: Error) {
-    addMessage({
-      role:                    Role.System,
-      messageContent:          (error as ChatError).message,
-      actions:                 [{
-        label:    t('ai.settings.goToAgents'),
-        type:     ActionType.Button,
-        resource: {
-          cluster:        'local',
-          detailLocation: { name: `c-cluster-settings-${ PRODUCT_NAME }` }
-        }
-      }],
-      timestamp: new Date(),
-      completed: true,
-      source:    MessageInternalSource.Error,
-    });
-  }
-
   function downloadMessages() {
     downloadFile(
       `Rancher-liz-chat-${ chatId }_${ new Date().toISOString().slice(0, 10) }.txt`,
@@ -514,6 +518,21 @@ export function useChatMessageComposable(
 
   function resetMessages() {
     store.commit('rancher-ai-ui/chat/resetMessages', chatId);
+  }
+
+  function resetChatMetadata(args: { chatId: string | null } = { chatId: null }) {
+    store.commit('rancher-ai-ui/chat/setMetadata', {
+      chatId:      args.chatId,
+      agents:      null,
+      storageType: null
+    });
+  }
+
+  function setErrors(error: ChatError | null = null) {
+    store.commit('rancher-ai-ui/chat/setError', {
+      chatId,
+      error,
+    });
   }
 
   function clearMessageBox() {
@@ -542,8 +561,11 @@ export function useChatMessageComposable(
     loadMessages,
     resetMessages,
     clearMessageBox,
+    chatMetadata,
     isChatInitialized,
+    resetChatMetadata,
     phase,
-    error
+    error,
+    resetErrors: () => setErrors(null),
   };
 }

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -163,6 +163,8 @@ ai:
     disconnected: 'Disconnected'
     connectionClosed: 'Connection closed'
   error:
+    chat:
+      generic: 'An error occurred initializing the chat'
     message:
       processing: 'Error processing messages: '
     websocket:

--- a/pkg/rancher-ai-ui/pages/Chat.vue
+++ b/pkg/rancher-ai-ui/pages/Chat.vue
@@ -6,7 +6,7 @@ import {
 } from 'vue';
 import { PRODUCT_NAME } from '../product';
 import {
-  Agent, AgentState, AIServiceState, ChatMetadata, ConnectionPhase, HistoryChat, Message, MessagePhase, StorageType
+  Agent, AgentState, AIServiceState, ConnectionPhase, HistoryChat, Message, MessagePhase, StorageType
 } from '../types';
 import { useConnectionComposable } from '../composables/useConnectionComposable';
 import { useChatMessageComposable } from '../composables/useChatMessageComposable';
@@ -56,8 +56,12 @@ const {
   loadMessages,
   selectContext,
   clearMessageBox,
+  chatMetadata,
   isChatInitialized,
+  resetChatMetadata,
   phase: messagePhase,
+  error: chatError,
+  resetErrors: resetChatErrors
 } = useChatMessageComposable(
   CHAT_ID,
   hasPermissions,
@@ -97,10 +101,6 @@ const {
 const showHistory = ref(false);
 const chatHistory = ref<HistoryChat[]>([]);
 
-const chatMetadata = computed<ChatMetadata>(() => {
-  return store.getters['rancher-ai-ui/chat/metadata'] || {};
-});
-
 const chatAgents = computed<Agent[]>(() => {
   return agents.value.map((agent) => {
     const chatAgent = chatMetadata.value.agents?.find((a) => a.name === agent?.name);
@@ -112,10 +112,12 @@ const chatAgents = computed<Agent[]>(() => {
   });
 });
 
-// AI service's errors are priority over websocket
+// AI service's errors are priority over websocket and chat errors
 const systemErrors = computed(() => {
   if (aiServiceError.value) {
     return [aiServiceError.value];
+  } else if (chatError.value) {
+    return [chatError.value];
   } else {
     return [
       wsError.value
@@ -167,7 +169,7 @@ async function ensureReconnectionAndLoadChat(chatId: string | null) {
   const initChat = async() => {
     loadMessages(chatId ? await fetchMessages(chatId) : []);
     nextTick(() => {
-      store.commit('rancher-ai-ui/chat/setMetadata', { chatId });
+      resetChatMetadata({ chatId });
       connect(chatId);
     });
   };
@@ -222,6 +224,8 @@ watch(() => aiAgentDeploymentState.value, (newState, oldState) => {
     storageType = StorageType.InMemory
   } = chatMetadata.value;
 
+  resetChatErrors();
+
   /**
    * AI agent became active on mount or after a service state update - connect to the existing chat if there is one in memory, otherwise start a new one
    */
@@ -236,11 +240,7 @@ watch(() => aiAgentDeploymentState.value, (newState, oldState) => {
     showHistory.value = false;
 
     if (storageType === StorageType.InMemory) {
-      store.commit('rancher-ai-ui/chat/setMetadata', {
-        chatId:      '',
-        agents:      null,
-        storageType: null
-      });
+      resetChatMetadata({ chatId: '' });
     }
 
     disconnect();

--- a/pkg/rancher-ai-ui/store/chat.ts
+++ b/pkg/rancher-ai-ui/store/chat.ts
@@ -1,6 +1,7 @@
 import { PRODUCT_NAME } from '../product';
 import { CoreStoreSpecifics, CoreStoreConfig } from '@shell/core/types';
 import {
+  ChatError,
   ChatMetadata,
   ConfirmationStatus, Message, MessageInternalSource, MessagePhase, Role
 } from '../types';
@@ -18,6 +19,7 @@ interface Chat {
   agentName?: string;
   messages: Record<string, Message>;
   phase?: MessagePhase;
+  error?: ChatError | null;
 }
 
 type MessageBox = Record<string, Message>;
@@ -72,6 +74,9 @@ const getters = {
 
     return MessagePhase.Idle;
   },
+  error: (state: State) => (chatId: string) => {
+    return state.chats[chatId]?.error || null;
+  },
   messageBox: (state: State) => (chatId: string) => {
     return state.messageBox[chatId];
   },
@@ -97,6 +102,10 @@ const mutations = {
   },
 
   setMetadata(state: State, metadata: ChatMetadata) {
+    if (state.metadata?.chatId && state.chats[state.metadata.chatId]) {
+      state.chats[state.metadata.chatId].error = null;
+    }
+
     state.metadata = {
       ...state.metadata,
       ...metadata
@@ -189,6 +198,16 @@ const mutations = {
     }
 
     state.chats[chatId].phase = phase;
+  },
+
+  setError(state: State, args: { chatId: string; error: ChatError | null }) {
+    const { chatId, error } = args;
+
+    if (!chatId || !state.chats[chatId]) {
+      return;
+    }
+
+    state.chats[chatId].error = error;
   },
 
   addToMessageBox(state: State, args: { chatId: string; message: Message }) {


### PR DESCRIPTION
The errors sent in the `<chat-error>` payload are currently handled as message errors (For example, when there are no agents available in the system), so the chat remains in active state.

However, In this scenario, we should disable the chat as the error is not recoverable and handle it as system error.

[Screencast from 2026-03-11 16-37-25.webm](https://github.com/user-attachments/assets/9c0d982a-8f4c-40a0-815e-982335254b16)


This change will ensure those errors will be handled as system errors:

[Screencast from 2026-03-11 16-39-00.webm](https://github.com/user-attachments/assets/9acf2cd3-2549-4a0c-9d54-f36ce30d9a96)

