### PR TITLE
Fix sliding badges position in ResourceTables

### DIFF
--- a/cypress/e2e/blueprints/pod.ts
+++ b/cypress/e2e/blueprints/pod.ts
@@ -15,3 +15,21 @@ export const testPod = {
     ]
   }
 };
+
+export const errorPod = {
+  apiVersion: 'v1',
+  kind:       'Pod',
+  metadata:   {
+    name:      'error-pod',
+    namespace: 'default',
+    labels:    {}
+  },
+  spec: {
+    containers: [
+      {
+        name:  'container-0',
+        image: 'aaa'
+      }
+    ]
+  }
+};

--- a/cypress/e2e/po/hook.po.ts
+++ b/cypress/e2e/po/hook.po.ts
@@ -1,10 +1,6 @@
 import ComponentPo from '@rancher/cypress/e2e/po/components/component.po';
 
 class TargetPo extends ComponentPo {
-  constructor(element: Cypress.Chainable) {
-    super(element);
-  }
-
   /**
    * Checks if the target element has an action registered for its hook.
    */
@@ -16,8 +12,8 @@ class TargetPo extends ComponentPo {
 class HookPo {
   protected target: TargetPo;
 
-  constructor(target: Cypress.Chainable) {
-    this.target = new TargetPo(target);
+  constructor(target: string | Cypress.Chainable) {
+    this.target = new TargetPo(target as any);
   }
 }
 
@@ -29,10 +25,10 @@ export class SlidingBadgePo extends HookPo {
     this.target.self().trigger('mouseenter', { force: true });
 
     // Trigger mouse enter on the sliding badge to reveal its second stage
-    const slidingBadge = this.target.self().get('[data-testid="rancher-ai-ui-sliding-badge"]');
+    const slidingBadge = this.target.self().get('[data-testid="rancher-ai-ui-hook-overlay"]');
 
     slidingBadge.trigger('mouseenter', { force: true });
 
-    slidingBadge.click();
+    slidingBadge.click({ force: true });
   }
 }

--- a/cypress/e2e/tests/features/hooks.spec.ts
+++ b/cypress/e2e/tests/features/hooks.spec.ts
@@ -1,8 +1,10 @@
 import HomePagePo from '@rancher/cypress/e2e/po/pages/home.po';
+import { WorkLoadsPodDetailsPagePo } from '@rancher/cypress/e2e/po/pages/explorer/workloads-pods.po';
 
 import { SlidingBadgePo } from '@/cypress/e2e/po/hook.po';
 import ChatPo from '@/cypress/e2e/po/chat.po';
 import { HistoryPo } from '../../po/history.po';
+import { errorPod } from '@/cypress/e2e/blueprints/pod';
 
 describe('Hooks', () => {
   const chat = new ChatPo();
@@ -10,9 +12,136 @@ describe('Hooks', () => {
 
   beforeEach(() => {
     cy.login();
+    cy.cleanChatHistory();
   });
 
   describe('Sliding badge hook', () => {
+    before(() => {
+      cy.login();
+      cy.createRancherResource('v1', 'pods', JSON.stringify(errorPod), false);
+    });
+
+    it('It should activate the sliding badge from: Sortable Table row', () => {
+      const homePage = new HomePagePo();
+
+      HomePagePo.goTo();
+
+      chat.open();
+
+      const welcomeMessage = chat.getMessage(1);
+
+      welcomeMessage.isCompleted();
+
+      const homeClusterList = homePage.list();
+
+      // Get the status column of the first row in the cluster list (local cluster)
+      const statusColumn = homeClusterList.resourceTable().sortableTable().row(0).column(0);
+
+      const slidingBadge = new SlidingBadgePo(statusColumn);
+
+      slidingBadge.click();
+
+      const message = chat.getMessage(2);
+
+      message.containsText('Please analyse the Cluster "local" and troubleshoot any problems.');
+      message.containsText('See More');
+
+      const response = chat.getMessage(3);
+
+      response.isCompleted();
+
+      history.open();
+
+      const chatItem = history.chatItem(0);
+
+      chatItem.self().contains('Please analyse the Cluster "local" and troubleshoot any problems.');
+
+      chatItem.showTooltip();
+
+      chatItem.tooltip().containsText('Please analyse the Cluster "local" and troubleshoot any problems.');
+      chatItem.tooltip().notContainsText('Explain what the "active" state means');
+      chatItem.tooltip().containsText('Started on');
+    });
+
+    it('It should activate the sliding badge from: Details State banner', () => {
+      const podDetails = new WorkLoadsPodDetailsPagePo(errorPod.metadata.name);
+
+      podDetails.goTo();
+      podDetails.waitForPage();
+
+      // Remove title from pod details page to make sure the sliding badge is visible
+      podDetails.self().get('.resource-name.masthead-resource-title').invoke('remove');
+
+      chat.open();
+
+      const welcomeMessage = chat.getMessage(1);
+
+      welcomeMessage.isCompleted();
+
+      const slidingBadge = new SlidingBadgePo('.title > .badge-state.bg-info');
+
+      slidingBadge.click();
+
+      const message = chat.getMessage(2);
+
+      message.containsText('Please analyse the Pod "error-pod" and troubleshoot any problems.');
+      message.containsText('See More');
+
+      const response = chat.getMessage(3);
+
+      response.isCompleted();
+
+      history.open();
+
+      const chatItem = history.chatItem(0);
+
+      chatItem.self().contains('Please analyse the Pod "error-pod" and troubleshoot any problems.');
+
+      chatItem.showTooltip();
+
+      chatItem.tooltip().containsText('Please analyse the Pod "error-pod" and troubleshoot any problems.');
+      chatItem.tooltip().notContainsText('Explain what');
+      chatItem.tooltip().containsText('Started on');
+    });
+
+    it('It should activate the sliding badge from: Status banner', () => {
+      const podDetails = new WorkLoadsPodDetailsPagePo(errorPod.metadata.name);
+
+      podDetails.goTo();
+      podDetails.waitForPage();
+
+      chat.open();
+
+      const welcomeMessage = chat.getMessage(1);
+
+      welcomeMessage.isCompleted();
+
+      const slidingBadge = new SlidingBadgePo('[data-testid="banner-content"]');
+
+      slidingBadge.click();
+
+      const message = chat.getMessage(2);
+
+      message.containsText('Hey Liz, please analyse the "containers with unready status: [container-0]" message and troubleshoot any problems.');
+      message.containsText('See More');
+
+      const response = chat.getMessage(3);
+
+      response.isCompleted();
+
+      history.open();
+
+      const chatItem = history.chatItem(0);
+
+      chatItem.self().contains('Hey Liz, please analyse the "containers with unready status: [container-0]" message and troubleshoot any problems.');
+
+      chatItem.showTooltip();
+
+      chatItem.tooltip().containsText('Hey Liz, please analyse the "containers with unready status: [container-0]" message and troubleshoot any problems.');
+      chatItem.tooltip().notContainsText('Explain what');
+      chatItem.tooltip().containsText('Started on');
+    });
+
     it('It should send a message from the sliding badge when the chat is closed and ready', () => {
       const homePage = new HomePagePo();
 
@@ -137,5 +266,13 @@ describe('Hooks', () => {
 
       chat.getMessage(2).checkNotExists();
     });
+
+    after(() => {
+      cy.deleteRancherResource('v1', 'pods', `${ errorPod.metadata.namespace }/${ errorPod.metadata.name }`, false);
+    });
+  });
+
+  after(() => {
+    cy.cleanChatHistory();
   });
 });

--- a/pkg/rancher-ai-ui/handlers/__tests__/hooks.handler.test.ts
+++ b/pkg/rancher-ai-ui/handlers/__tests__/hooks.handler.test.ts
@@ -1,0 +1,406 @@
+import {
+  describe, it, expect, beforeEach, jest, afterEach
+} from '@jest/globals';
+import HooksHandler from '../hooks/index';
+import { HooksOverlay } from '../hooks/overlay';
+import { Context } from '../../types';
+
+jest.mock('vue', () => ({
+  watch: jest.fn(),
+  ref:   jest.fn((val) => ({ value: val }))
+}));
+
+describe('HooksHandler', () => {
+  let mockStore: any;
+  let mockOverlay: any;
+  let mockTarget: HTMLElement;
+  let mockContext: Context;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Reset singleton state - access static properties through the class
+    const HooksHandlerClass = Object.getPrototypeOf(HooksHandler).constructor;
+
+    HooksHandlerClass.initialized = false;
+    HooksHandlerClass.headerBtn = null;
+    HooksHandlerClass.allHooksKeyPressed = false;
+    HooksHandlerClass.targets = new Set();
+    HooksHandlerClass.overlays = [];
+
+    // Mock store
+    mockStore = {
+      getters: {
+        'ui-context/all':            jest.fn(() => []),
+        'prefs/theme':               jest.fn(() => 'light'),
+        'rancher-ai-ui/context/all': jest.fn(() => ({}))
+      },
+      commit:   jest.fn(),
+      dispatch: jest.fn()
+    };
+
+    // Mock overlay
+    mockOverlay = {
+      getSelector: jest.fn(() => 'test-overlay'),
+      create:      jest.fn(),
+      destroy:     jest.fn(),
+      setTheme:    jest.fn()
+    };
+
+    // Mock target element
+    mockTarget = document.createElement('div');
+    mockTarget.setAttribute('ux-context-hook-id', 'test-hook-id');
+    document.body.appendChild(mockTarget);
+
+    // Mock context
+    mockContext = {
+      hookId: 'test-hook-id',
+      action: 'test-action'
+    } as any;
+  });
+
+  afterEach(() => {
+    // Reset all static state - access through the class, not the instance
+    const HooksHandlerClass = Object.getPrototypeOf(HooksHandler).constructor;
+
+    (HooksHandlerClass as any).allHooksKeyPressed = false;
+    HooksHandlerClass.headerBtn = null;
+    HooksHandlerClass.initialized = false;
+    HooksHandlerClass.targets = new Set();
+    HooksHandlerClass.overlays = [];
+    // Clean up DOM
+    document.body.innerHTML = '';
+  });
+
+  describe('inject', () => {
+    it('should add overlay to overlays array', () => {
+      // Test core logic without triggering watch
+      (HooksHandler as any).overlays = [];
+
+      (HooksHandler as any).overlays.push(mockOverlay);
+
+      expect((HooksHandler as any).overlays).toContain(mockOverlay);
+    });
+
+    it('should not add duplicate overlays', () => {
+      (HooksHandler as any).overlays = [];
+
+      (HooksHandler as any).overlays.push(mockOverlay);
+      const lengthAfterFirst = (HooksHandler as any).overlays.length;
+
+      // Simulate duplicate check
+      const isDuplicate = (HooksHandler as any).overlays.find((o: any) => o.getSelector() === mockOverlay.getSelector());
+
+      if (!isDuplicate) {
+        (HooksHandler as any).overlays.push(mockOverlay);
+      }
+
+      expect((HooksHandler as any).overlays.length).toBe(lengthAfterFirst);
+    });
+
+    it('should add different overlays', () => {
+      (HooksHandler as any).overlays = [];
+
+      const mockOverlay2 = {
+        getSelector: jest.fn(() => 'test-overlay-2'),
+        create:      jest.fn(),
+        destroy:     jest.fn(),
+        setTheme:    jest.fn()
+      } as any;
+
+      (HooksHandler as any).overlays.push(mockOverlay);
+      (HooksHandler as any).overlays.push(mockOverlay2);
+
+      expect((HooksHandler as any).overlays).toHaveLength(2);
+    });
+  });
+
+  describe('toggleAllHooksOverlay', () => {
+    it('should set allHooksKeyPressed to true when toggling on', () => {
+      const setAllHooksKeyPressedSpy = jest.spyOn(HooksOverlay, 'setAllHooksKeyPressed');
+
+      HooksHandler.toggleAllHooksOverlay(mockStore, true);
+
+      expect(setAllHooksKeyPressedSpy).toHaveBeenCalledWith(true);
+      expect(setAllHooksKeyPressedSpy).toHaveBeenCalled();
+    });
+
+    it('should set allHooksKeyPressed to false when toggling off', () => {
+      const setAllHooksKeyPressedSpy = jest.spyOn(HooksOverlay, 'setAllHooksKeyPressed');
+
+      HooksHandler.toggleAllHooksOverlay(mockStore, false);
+
+      expect(setAllHooksKeyPressedSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('should notify overlay when toggling all hooks', () => {
+      const setAllHooksKeyPressedSpy = jest.spyOn(HooksOverlay, 'setAllHooksKeyPressed');
+
+      HooksHandler.toggleAllHooksOverlay(mockStore, true);
+
+      expect(setAllHooksKeyPressedSpy).toHaveBeenCalledWith(true);
+    });
+
+    it('should toggle overlays for all targets when enabled', () => {
+      // Set up overlays first
+      (HooksHandler as any).overlays = [mockOverlay];
+
+      // Add a target to the handler
+      (HooksHandler as any).targets.add({
+        target:   mockTarget,
+        ctx:      mockContext,
+        handlers: {}
+      });
+
+      const toggleOverlaysSpy = jest.spyOn(HooksHandler as any, 'toggleOverlays');
+
+      HooksHandler.toggleAllHooksOverlay(mockStore, true);
+
+      expect(toggleOverlaysSpy).toHaveBeenCalledWith(mockStore, mockTarget, mockContext, true);
+    });
+  });
+
+  describe('clearTargets', () => {
+    it('should remove all event listeners from targets', () => {
+      const mouseenterHandler = jest.fn();
+      const mouseleaveHandler = jest.fn();
+      const removeEventListenerSpy = jest.spyOn(mockTarget, 'removeEventListener');
+
+      (HooksHandler as any).targets.add({
+        target:   mockTarget,
+        ctx:      mockContext,
+        handlers: {
+          mouseenter: mouseenterHandler,
+          mouseleave: mouseleaveHandler
+        }
+      });
+
+      (HooksHandler as any).clearTargets();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('mouseenter', mouseenterHandler);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('mouseleave', mouseleaveHandler);
+    });
+
+    it('should remove ux-context-hook-status attribute', () => {
+      (HooksHandler as any).targets.add({
+        target:   mockTarget,
+        ctx:      mockContext,
+        handlers: {}
+      });
+
+      mockTarget.setAttribute('ux-context-hook-status', 'bound');
+
+      (HooksHandler as any).clearTargets();
+
+      expect(mockTarget.getAttribute('ux-context-hook-status')).toBeNull();
+    });
+
+    it('should clear targets set', () => {
+      (HooksHandler as any).targets.add({
+        target:   mockTarget,
+        ctx:      mockContext,
+        handlers: {}
+      });
+
+      (HooksHandler as any).clearTargets();
+
+      expect((HooksHandler as any).targets.size).toBe(0);
+    });
+
+    it('should handle errors when removing event listeners', () => {
+      const removeEventListenerSpy = jest.spyOn(mockTarget, 'removeEventListener').mockImplementation(() => {
+        throw new Error('Remove listener error');
+      });
+
+      (HooksHandler as any).targets.add({
+        target:   mockTarget,
+        ctx:      mockContext,
+        handlers: {
+          mouseenter: jest.fn(),
+          mouseleave: jest.fn()
+        }
+      });
+
+      expect(() => (HooksHandler as any).clearTargets()).not.toThrow();
+      expect(removeEventListenerSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('getOverlayHTMLElement', () => {
+    it('should return target if it has overlay selector class', () => {
+      mockTarget.classList.add('test-overlay');
+
+      const result = (HooksHandler as any).getOverlayHTMLElement(mockTarget, mockOverlay);
+
+      expect(result).toBe(mockTarget);
+    });
+
+    it('should return nested element if it has overlay selector class', () => {
+      const nestedElement = document.createElement('div');
+
+      nestedElement.classList.add('test-overlay');
+      mockTarget.appendChild(nestedElement);
+
+      const result = (HooksHandler as any).getOverlayHTMLElement(mockTarget, mockOverlay);
+
+      expect(result).toBe(nestedElement);
+    });
+
+    it('should return null if overlay selector not found', () => {
+      const result = (HooksHandler as any).getOverlayHTMLElement(mockTarget, mockOverlay);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('toggleOverlays', () => {
+    beforeEach(() => {
+      mockTarget.classList.add('test-overlay');
+      (HooksHandler as any).overlays = [mockOverlay];
+    });
+
+    it('should call overlay.create when show is true', () => {
+      (HooksHandler as any).toggleOverlays(mockStore, mockTarget, mockContext, true);
+
+      expect(mockOverlay.create).toHaveBeenCalledWith(
+        mockStore,
+        mockTarget,
+        mockTarget,
+        mockContext,
+        expect.any(Function)
+      );
+    });
+
+    it('should call overlay.destroy when show is false and element is not hovered', () => {
+      (HooksHandler as any).toggleOverlays(mockStore, mockTarget, mockContext, false);
+
+      expect(mockOverlay.destroy).toHaveBeenCalledWith(mockTarget);
+    });
+
+    it('should not call overlay.destroy when element is hovered', () => {
+      (mockTarget as any).matches = jest.fn(() => true);
+
+      (HooksHandler as any).toggleOverlays(mockStore, mockTarget, mockContext, false);
+
+      expect(mockOverlay.destroy).not.toHaveBeenCalled();
+    });
+
+    it('should skip overlay if overlay element not found', () => {
+      mockTarget.classList.remove('test-overlay');
+
+      (HooksHandler as any).toggleOverlays(mockStore, mockTarget, mockContext, true);
+
+      expect(mockOverlay.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isShowAllHooksKey', () => {
+    beforeEach(() => {
+      const HooksHandlerClass = Object.getPrototypeOf(HooksHandler).constructor;
+
+      (HooksHandlerClass as any).allHooksKeyPressed = false;
+    });
+
+    it('should return true for Ctrl+Alt+L key combination', () => {
+      const event = new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        altKey:  true,
+        key:     'l'
+      });
+
+      const result = (HooksHandler as any).isShowAllHooksKey(event);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for other key combinations', () => {
+      const event = new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        altKey:  false,
+        key:     'l'
+      });
+
+      const result = (HooksHandler as any).isShowAllHooksKey(event);
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle key release for key chain', () => {
+      const HooksHandlerClass = Object.getPrototypeOf(HooksHandler).constructor;
+
+      (HooksHandlerClass as any).allHooksKeyPressed = true;
+
+      const event = {
+        type: 'keyup',
+        key:  'Control'
+      } as any;
+
+      const result = (HooksHandler as any).isShowAllHooksKey(event);
+
+      expect(result).toBe(true);
+    });
+
+    it('should be case insensitive for letter keys', () => {
+      const eventUpperCase = new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        altKey:  true,
+        key:     'L'
+      });
+
+      const eventLowerCase = new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        altKey:  true,
+        key:     'l'
+      });
+
+      const resultUpper = (HooksHandler as any).isShowAllHooksKey(eventUpperCase);
+      const resultLower = (HooksHandler as any).isShowAllHooksKey(eventLowerCase);
+
+      expect(resultUpper).toBe(true);
+      expect(resultLower).toBe(true);
+    });
+  });
+
+  describe('addEasterEgg', () => {
+    it('should add event listeners to header button', () => {
+      const headerBtn = document.createElement('button');
+
+      headerBtn.className = 'header-btn';
+      const iconAi = document.createElement('i');
+
+      iconAi.className = 'icon-ai';
+      headerBtn.appendChild(iconAi);
+      document.body.appendChild(headerBtn);
+
+      const addEventListenerSpy = jest.spyOn(headerBtn, 'addEventListener');
+
+      (HooksHandler as any).addEasterEgg(mockStore);
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith('mouseenter', expect.any(Function));
+      expect(addEventListenerSpy).toHaveBeenCalledWith('mouseleave', expect.any(Function));
+      expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+    });
+
+    it('should remove previous event listeners before adding new ones', () => {
+      const headerBtn = document.createElement('button');
+
+      headerBtn.className = 'header-btn';
+      const iconAi = document.createElement('i');
+
+      iconAi.className = 'icon-ai';
+      headerBtn.appendChild(iconAi);
+      document.body.appendChild(headerBtn);
+
+      // First call
+      (HooksHandler as any).addEasterEgg(mockStore);
+      const removeEventListenerSpy = jest.spyOn(headerBtn, 'removeEventListener');
+
+      // Second call
+      (HooksHandler as any).addEasterEgg(mockStore);
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('mouseenter', expect.any(Function));
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('mouseleave', expect.any(Function));
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+    });
+  });
+});

--- a/pkg/rancher-ai-ui/handlers/hooks/overlay/badge-sliding.ts
+++ b/pkg/rancher-ai-ui/handlers/hooks/overlay/badge-sliding.ts
@@ -174,7 +174,8 @@ class BadgeSlidingOverlay extends HooksOverlay {
     const badgeRect = badge.getBoundingClientRect();
     const badgeStyle = getComputedStyle(badge);
 
-    overlay.setAttribute('data-testid', 'rancher-ai-ui-sliding-badge');
+    overlay.setAttribute('data-testid', 'rancher-ai-ui-hook-overlay');
+
     overlay.classList.add(`${ HooksOverlay.defaultClassPrefix }-${ this.getSelector() }`);
     overlay.style.zIndex = '10';
     overlay.style.backgroundColor = overlayProps.background;

--- a/pkg/rancher-ai-ui/handlers/hooks/overlay/badge-sliding.ts
+++ b/pkg/rancher-ai-ui/handlers/hooks/overlay/badge-sliding.ts
@@ -2,7 +2,7 @@ import { nextTick } from 'vue';
 import { Store } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import { warn } from '../../../utils/log';
-import { Context } from '../../../types';
+import { Context, HookContextTag } from '../../../types';
 import { HooksOverlay } from './index';
 import TemplateMessage from '../template-message';
 import Chat from '../../chat';
@@ -21,6 +21,8 @@ class BadgeSlidingOverlay extends HooksOverlay {
     super();
     this.selector = selector;
   }
+
+  private hookContextTag: HookContextTag | null = null;
 
   /**
    * Compute the theme properties for the badge and overlay.
@@ -70,13 +72,13 @@ class BadgeSlidingOverlay extends HooksOverlay {
   }
 
   /**
-   * Handle changes in the parent container's position (e.g. due to scrolling or table resizing).
+   * Handle changes in the container's position (e.g. due to scrolling or table resizing).
    * @param target The target element.
-   * @param container The parent container element.
+   * @param container The container element.
    * @param overlay The overlay element.
    */
-  private handleParentPositionChange(target: HTMLElement, container: HTMLElement, overlay: HTMLElement) {
-    // destroy overlay if the container/parent moves (position changes)
+  private handleContainerPositionChange(target: HTMLElement, container: HTMLElement, overlay: HTMLElement) {
+    // Destroy overlay if the container moves (position changes)
     let lastContainerRect = container.getBoundingClientRect();
     let rafId: number | null = null;
 
@@ -90,7 +92,7 @@ class BadgeSlidingOverlay extends HooksOverlay {
           const r = container.getBoundingClientRect();
 
           if (r.top !== lastContainerRect.top || r.left !== lastContainerRect.left) {
-            // parent moved -> remove overlays for this target, immediately
+            // The container moved -> remove overlays for this target, immediately
             this.destroy(target, true);
           } else {
             lastContainerRect = r;
@@ -117,7 +119,7 @@ class BadgeSlidingOverlay extends HooksOverlay {
     window.addEventListener('scroll', scrollHandler, true);
 
     // attach cleanup so destroy() can call it (avoid leaks if overlay removed directly)
-    (overlay as any).__parentPositionCleanup = () => {
+    (overlay as any).__containerPositionCleanup = () => {
       try {
         if (rafId !== null) {
           cancelAnimationFrame(rafId);
@@ -144,19 +146,21 @@ class BadgeSlidingOverlay extends HooksOverlay {
   }
 
   /**
-   * Cleanup parent position change handlers
+   * Cleanup container position change handlers
    */
-  private cleanupParentPosition(overlay: any) {
+  private cleanupContainerPosition(overlay: any) {
     try {
-      if (typeof overlay.__parentPositionCleanup === 'function') {
-        overlay.__parentPositionCleanup();
+      if (typeof overlay.__containerPositionCleanup === 'function') {
+        overlay.__containerPositionCleanup();
       }
     } catch (e) {
-      warn('Error during parent position cleanup', e);
+      warn('Error during container position cleanup', e);
     }
   }
 
   create(store: Store<any>, target: HTMLElement, badge: HTMLElement, ctx: Context, globalCtx: Context[] = []) {
+    this.hookContextTag = ctx.tag as HookContextTag;
+
     const { t } = useI18n(store);
     const theme = store.getters['prefs/theme'] as Theme;
 
@@ -212,7 +216,7 @@ class BadgeSlidingOverlay extends HooksOverlay {
 
     overlay.appendChild(icon);
 
-    const container = (target.parentElement || target) as HTMLElement;
+    const container = this.getContainer(target);
 
     container.appendChild(overlay);
 
@@ -221,7 +225,7 @@ class BadgeSlidingOverlay extends HooksOverlay {
       overlay.style.width = `${ parseInt(overlay.style.width) + 30 }px`;
     }, 10);
 
-    this.handleParentPositionChange(target, container, overlay);
+    this.handleContainerPositionChange(target, container, overlay);
 
     overlay.addEventListener('click', (e) => {
       this.action(store, e, overlay, ctx, globalCtx);
@@ -257,13 +261,13 @@ class BadgeSlidingOverlay extends HooksOverlay {
   }
 
   destroy(target: HTMLElement, immediate = false) {
-    (target.parentElement as HTMLElement).querySelectorAll(`.${ HooksOverlay.defaultClassPrefix }-${ this.getSelector() }`).forEach((overlay: any) => {
+    this.getContainer(target).querySelectorAll(`.${ HooksOverlay.defaultClassPrefix }-${ this.getSelector() }`).forEach((overlay: any) => {
       if (overlay) {
         if (immediate) {
-          this.cleanupParentPosition(overlay);
+          this.cleanupContainerPosition(overlay);
           overlay.remove();
         } else if (!(overlay.matches(':hover') || (overlay.querySelector(':hover') !== null))) {
-          this.cleanupParentPosition(overlay);
+          this.cleanupContainerPosition(overlay);
 
           // Animate width shrink before removing
           overlay.style.transition = 'width 0.2s cubic-bezier(0.4,0,0.2,1), opacity 0.3s';
@@ -276,6 +280,21 @@ class BadgeSlidingOverlay extends HooksOverlay {
         }
       }
     });
+  }
+
+  // Select the appropriate container based on the context tag
+  getContainer(target: HTMLElement): HTMLElement {
+    let container;
+
+    switch (this.hookContextTag) {
+    case HookContextTag.SortableTableRow:
+      container = target.closest('tbody');
+      break;
+    default:
+      container = target.parentElement;
+    }
+
+    return (container || target) as HTMLElement;
   }
 
   setTheme(badge: HTMLElement, theme: Theme) {

--- a/pkg/rancher-ai-ui/handlers/hooks/overlay/banner-button.ts
+++ b/pkg/rancher-ai-ui/handlers/hooks/overlay/banner-button.ts
@@ -23,6 +23,8 @@ class BannerButtonOverlay extends HooksOverlay {
     const color = (ctx.value as any)?.bannerProps?.color || 'success';
     const height = 24;
 
+    overlay.setAttribute('data-testid', 'rancher-ai-ui-hook-overlay');
+
     overlay.className = `${ HooksOverlay.defaultClassPrefix }-${ this.getSelector() }`;
 
     overlay.style.position = 'fixed';


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-ui/issues/122

The sliding badges are currently mounted as siblings of the other `td` elements in the Resource Tables. This is causing some glitches since the new sibling pushes the other columns to the right of the status column.

We are fixing the issue by mounting the badges as child of table's `tbody` element so that it doesn't collide with the table's columns.

### Screenshots

Before

https://github.com/user-attachments/assets/18b55ca4-ca38-4b12-96b4-10d26fddf30c

After

https://github.com/user-attachments/assets/b6147a3e-8bcb-481e-8416-5e659cde38e8

