### PR TITLE
Fix downstream resource buttons

### DIFF
--- a/pkg/rancher-ai-ui/components/message/action/Action.vue
+++ b/pkg/rancher-ai-ui/components/message/action/Action.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, type PropType } from 'vue';
+import { computed, onMounted, type PropType } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import { warn } from '../../../utils/log';
@@ -32,8 +32,6 @@ const to = computed(() => {
 
   return store.getters[`${ inStore }/byId`](convertedType, id);
 });
-
-const tooltip = ref<string>('');
 
 const label = computed(() => {
   if (props.value.label) {
@@ -111,7 +109,6 @@ onMounted(async() => {
     :data-testid="`rancher-ai-ui-chat-message-action-button-${ props.value?.resource?.name }`"
   >
     <RcButton
-      v-clean-tooltip="tooltip"
       small
       secondary
       :disabled="!to"
@@ -125,7 +122,6 @@ onMounted(async() => {
   <span v-if="props.value.type === ActionType.Link">
     <a
       v-if="to"
-      v-clean-tooltip="tooltip"
       class="link"
       @click="goTo"
     >


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-ui/issues/115

The `management/find` doesn't work for the resources in downstream clusters.
We are fixing it by using the `/k8s/clusters` API.

## Test

- Ask Liz to display some resources in a downstream cluster: "List all deployments in fleet-8 cluster"
- Ask Liz to display some resources in local cluster
- Verify the links work for both local and downstream cluster's resources.

[Screencast from 2026-03-16 14-32-42.webm](https://github.com/user-attachments/assets/d8c99cd1-99aa-441a-ad49-325a1ddf54e9)
