### PR TITLE
Fix welcome message processing

### DIFF
--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -188,6 +188,7 @@ export function useChatMessageComposable(
           message: t('ai.message.system.welcome.info', {}, true),
         }
       },
+      source:    MessageInternalSource.Welcome,
       completed: false,
     };
   }
@@ -303,10 +304,16 @@ export function useChatMessageComposable(
     } else {
       try {
         /**
-         * Check if the chat is empty or there is a message in the message box,
-         * it means the welcome message is being processed or not required.
+         * No messages in the chat, next message should be welcome message.
          */
-        if (!messages.value.find((msg) => msg.completed || msg.source === MessageInternalSource.MessageBox)) {
+        const isEmptyChat = messages.value.length === 0;
+
+        /**
+         * Welcome message is in progress, continue processing it.
+         */
+        const welcomeMessageInProgress = messages.value.find((msg) => msg.source === MessageInternalSource.Welcome && !msg.completed);
+
+        if (isEmptyChat || welcomeMessageInProgress) {
           setPhase(MessagePhase.Initializing);
           await processWelcomeData(data);
         } else {

--- a/pkg/rancher-ai-ui/types.ts
+++ b/pkg/rancher-ai-ui/types.ts
@@ -199,6 +199,7 @@ export const enum MessageLabelKey {
 }
 
 export const enum MessageInternalSource {
+  Welcome = 'welcome',
   MessageBox = 'messageBox',
   Error = 'error',
 }


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-ui/issues/176

When the user sends a message from a sliding badges and the welcome is still being processed, what happens is:

- The UI stops parsing the data as welcome message payload.
- The Welcome Message receives extraneous data that are not meant to be part of the WelcomeMessage template, for instance, the `agent-metadata`, and shows it as plain text.

The bug can be reproduced with very slow models, so the welcome message is not completed quickly by the UI.

This change will ensure that, when there is an ongoing welcome message process, the UI continues processing the incoming data as 'welcome' data before moving on the next request.

[Screencast from 2026-03-17 11-57-30.webm](https://github.com/user-attachments/assets/606da504-73ee-4fe4-a2e3-f9b5cbf048be)
