### PR TITLE
Fix console warnings

### DIFF
--- a/pkg/rancher-ai-ui/components/ListOptions.vue
+++ b/pkg/rancher-ai-ui/components/ListOptions.vue
@@ -63,7 +63,7 @@ const hoveredIndex = ref<number | null>(null);
           <div class="button-group">
             <RcButton
               class="button-group-label"
-              tertiary
+              variant="tertiary"
               small
               :data-testid="`rancher-ai-ui-chat-message-list-option-${index}`"
               @click="props.disabled ? undefined : emit('select', option)"

--- a/pkg/rancher-ai-ui/components/agent/SelectAgent.vue
+++ b/pkg/rancher-ai-ui/components/agent/SelectAgent.vue
@@ -108,7 +108,7 @@ const isOpen = ref(false);
       @update:open="isOpen = $event"
     >
       <rc-dropdown-trigger
-        ghost
+        variant="ghost"
         small
         class="agent-trigger"
         :disabled="props.disabled"

--- a/pkg/rancher-ai-ui/components/agent/SelectAgent.vue
+++ b/pkg/rancher-ai-ui/components/agent/SelectAgent.vue
@@ -85,6 +85,12 @@ const selectedAgentName = computed<string>(() => {
   return props.agentName;
 });
 
+const selectedAgentLabel = computed(() => {
+  const agent = options.value?.find((opt) => opt.name === selectedAgentName.value);
+
+  return agent?.displayName || t('ai.agents.items.unknown');
+});
+
 const debouncedSelectAgent = debounce((id: string) => {
   emit('select', id === ADAPTIVE_MODE_ID ? '' : id);
 }, 100);
@@ -110,7 +116,7 @@ const isOpen = ref(false);
         <span
           class="selected-agent-name"
         >
-          {{ options?.find(opt => opt.name === selectedAgentName)?.displayName || t('ai.agents.items.unknown') }}
+          {{ selectedAgentLabel }}
         </span>
         <i
           class="icon icon-chevron-down chevron-icon"

--- a/pkg/rancher-ai-ui/components/context/SelectContext.vue
+++ b/pkg/rancher-ai-ui/components/context/SelectContext.vue
@@ -91,7 +91,7 @@ function reset() {
         @update:open="isOpen = $event"
       >
         <rc-dropdown-trigger
-          ghost
+          variant="ghost"
           small
           class="context-trigger"
           :disabled="props.disabled"
@@ -144,7 +144,7 @@ function reset() {
     >
       <RcButton
         small
-        tertiary
+        variant="tertiary"
         @click="reset"
       >
         <i class="icon icon-refresh mr-5" />

--- a/pkg/rancher-ai-ui/components/context/SelectContext.vue
+++ b/pkg/rancher-ai-ui/components/context/SelectContext.vue
@@ -85,50 +85,51 @@ function reset() {
     v-if="props.options.length > 0"
     class="context-select"
   >
-    <rc-dropdown
-      class="context-dropdown"
-      placement="top-end"
-      @update:open="isOpen = $event"
-    >
-      <rc-dropdown-trigger
-        ghost
-        small
-        class="context-trigger"
-        :disabled="props.disabled"
+    <div class="context-dropdown">
+      <rc-dropdown
+        placement="top-end"
+        @update:open="isOpen = $event"
       >
-        <span
-          class="context-trigger-text"
-          :class="{ 'ml-5': props.disabled }"
+        <rc-dropdown-trigger
+          ghost
+          small
+          class="context-trigger"
+          :disabled="props.disabled"
         >
-          {{ t('ai.context.add') }}
-        </span>
-      </rc-dropdown-trigger>
-      <template #dropdownCollection>
-        <rc-dropdown-item
-          v-for="(opt, i) in props.options"
-          :key="i"
-          v-clean-tooltip="opt.description"
-          @click="toggleItem(opt)"
-        >
-          {{ opt.tag }}:{{ contextLabel(opt) }}
-          <i
-            v-if="selected.find((s: Context) => _id(s) === _id(opt))"
-            :class="{
-              'icon icon-close': selected.find((s: Context) => _id(s) === _id(opt)),
-            }"
-          />
-          <template
-            #before
+          <span
+            class="context-trigger-text"
+            :class="{ 'ml-5': props.disabled }"
           >
+            {{ t('ai.context.add') }}
+          </span>
+        </rc-dropdown-trigger>
+        <template #dropdownCollection>
+          <rc-dropdown-item
+            v-for="(opt, i) in props.options"
+            :key="i"
+            v-clean-tooltip="opt.description"
+            @click="toggleItem(opt)"
+          >
+            {{ opt.tag }}:{{ contextLabel(opt) }}
             <i
-              v-if="opt.icon"
-              class="icon"
-              :class="opt.icon"
+              v-if="selected.find((s: Context) => _id(s) === _id(opt))"
+              :class="{
+                'icon icon-close': selected.find((s: Context) => _id(s) === _id(opt)),
+              }"
             />
-          </template>
-        </rc-dropdown-item>
-      </template>
-    </rc-dropdown>
+            <template
+              #before
+            >
+              <i
+                v-if="opt.icon"
+                class="icon"
+                :class="opt.icon"
+              />
+            </template>
+          </rc-dropdown-item>
+        </template>
+      </rc-dropdown>
+    </div>
     <div class="tags">
       <ContextTag
         v-for="(item, index) in selected"

--- a/pkg/rancher-ai-ui/components/context/SelectContext.vue
+++ b/pkg/rancher-ai-ui/components/context/SelectContext.vue
@@ -53,6 +53,10 @@ watch(() => props.options, (newVal) => {
   emit('update', selected.value);
 });
 
+function showRemoveIcon(item: Context) {
+  return !!selected.value.find((i) => _id(i) === _id(item));
+}
+
 function toggleItem(item: Context) {
   if (selected.value.find((i) => _id(i) === _id(item))) {
     removeItem(item);
@@ -112,10 +116,8 @@ function reset() {
           >
             {{ opt.tag }}:{{ contextLabel(opt) }}
             <i
-              v-if="selected.find((s: Context) => _id(s) === _id(opt))"
-              :class="{
-                'icon icon-close': selected.find((s: Context) => _id(s) === _id(opt)),
-              }"
+              v-if="showRemoveIcon(opt)"
+              class="icon icon-close"
             />
             <template
               #before

--- a/pkg/rancher-ai-ui/components/header/ChatPanelMenu.vue
+++ b/pkg/rancher-ai-ui/components/header/ChatPanelMenu.vue
@@ -70,7 +70,7 @@ const isOpen = ref(false);
       @update:open="isOpen = $event"
     >
       <rc-dropdown-trigger
-        ghost
+        variant="ghost"
         small
         :disabled="props.disabled"
       >

--- a/pkg/rancher-ai-ui/components/history/HistoryChatMenu.vue
+++ b/pkg/rancher-ai-ui/components/history/HistoryChatMenu.vue
@@ -48,7 +48,7 @@ const isOpen = ref(false);
       @update:open="isOpen = $event"
     >
       <rc-dropdown-trigger
-        ghost
+        variant="ghost"
         small
       >
         <i class="icon icon-actions" />

--- a/pkg/rancher-ai-ui/components/history/HistoryHeader.vue
+++ b/pkg/rancher-ai-ui/components/history/HistoryHeader.vue
@@ -36,7 +36,7 @@ function toggleHistory() {
         >
           <RcButton
             small
-            ghost
+            variant="ghost"
             class="btn-open-history"
             data-testid="rancher-ai-ui-chat-history-header-button"
             @click="toggleHistory"

--- a/pkg/rancher-ai-ui/components/message/Confirmation.vue
+++ b/pkg/rancher-ai-ui/components/message/Confirmation.vue
@@ -105,7 +105,7 @@ const confirmationText = computed(() => {
       >
         <RcButton
           small
-          tertiary
+          variant="tertiary"
           data-testid="rancher-ai-ui-chat-message-confirmation-cancel-button"
           @click="emit('confirm', false)"
         >
@@ -115,7 +115,7 @@ const confirmationText = computed(() => {
         </RcButton>
         <RcButton
           small
-          tertiary
+          variant="tertiary"
           data-testid="rancher-ai-ui-chat-message-confirmation-confirm-button"
           @click="emit('confirm', true)"
         >

--- a/pkg/rancher-ai-ui/components/message/index.vue
+++ b/pkg/rancher-ai-ui/components/message/index.vue
@@ -231,7 +231,7 @@ function handleToolAction(event: ToolActionEvent) {
           v-if="props.message.role === RoleEnum.Assistant && !!props.message.thinkingContent && props.message.showThinking"
           class="inline-button"
           small
-          ghost
+          variant="ghost"
           @click="handleShowThinking"
         >
           <a>{{ t('ai.message.actions.hideThinking') }}</a>
@@ -240,7 +240,7 @@ function handleToolAction(event: ToolActionEvent) {
           v-if="!!props.message.summaryContent"
           class="inline-button"
           small
-          ghost
+          variant="ghost"
           @click="handleShowCompleteMessage"
         >
           <a>{{ props.message.showCompleteMessage ? t('ai.message.actions.hideCompleteMessage') : t('ai.message.actions.showCompleteMessage') }}</a>

--- a/pkg/rancher-ai-ui/components/message/template/SystemSuggestion.vue
+++ b/pkg/rancher-ai-ui/components/message/template/SystemSuggestion.vue
@@ -74,7 +74,7 @@ function doAction(type: 'confirm' | 'cancel') {
           <RcButton
             v-if="actions.cancel?.action"
             small
-            tertiary
+            variant="tertiary"
             data-testid="rancher-ai-ui-chat-message-confirmation-cancel-button"
             @click="doAction('cancel')"
           >
@@ -85,7 +85,7 @@ function doAction(type: 'confirm' | 'cancel') {
           <RcButton
             v-if="actions.confirm?.action"
             small
-            secondary
+            variant="secondary"
             data-testid="rancher-ai-ui-chat-message-confirmation-confirm-button"
             @click="doAction('confirm')"
           >

--- a/pkg/rancher-ai-ui/components/panels/Header.vue
+++ b/pkg/rancher-ai-ui/components/panels/Header.vue
@@ -51,7 +51,7 @@ function toggleHistory() {
         >
           <RcButton
             small
-            ghost
+            variant="ghost"
             class="btn-open-history"
             data-testid="rancher-ai-ui-chat-history-button"
             :disabled="props.disabled"
@@ -87,7 +87,7 @@ function toggleHistory() {
     <div class="chat-close-btn">
       <RcButton
         small
-        ghost
+        variant="ghost"
         class="btn-close"
         data-testid="rancher-ai-ui-chat-close-button"
         @click="emit('close:chat')"

--- a/pkg/rancher-ai-ui/components/panels/History.vue
+++ b/pkg/rancher-ai-ui/components/panels/History.vue
@@ -122,7 +122,7 @@ function dismissEdit() {
         <div class="history-body">
           <RcButton
             ref="createBtn"
-            primary
+            variant="primary"
             class="btn-create-chat"
             data-testid="rancher-ai-ui-chat-history-create-chat-button"
             @click="createChat"
@@ -145,7 +145,7 @@ function dismissEdit() {
               <RcButton
                 v-for="(chat, index) in props.chats"
                 :key="chat.id"
-                tertiary
+                variant="tertiary"
                 class="history-chat-item"
                 :class="{
                   'focused': props.activeChatId === chat.id || editingChat?.id === chat.id

--- a/pkg/rancher-ai-ui/components/popover/TextLabel.vue
+++ b/pkg/rancher-ai-ui/components/popover/TextLabel.vue
@@ -34,7 +34,7 @@ const props = defineProps({
       placement="top"
     >
       <rc-dropdown-trigger
-        ghost
+        variant="ghost"
         small
         :disabled="props.disabled"
       >

--- a/pkg/rancher-ai-ui/components/toggle/toggle-group.vue
+++ b/pkg/rancher-ai-ui/components/toggle/toggle-group.vue
@@ -35,7 +35,7 @@ const update = (value: string) => {
       :key="item.name"
     >
       <rc-button
-        ghost
+        variant="ghost"
         class="toggle-group-item"
         :class="{ active: modelValue === item.value }"
         :disabled="props.disabled && modelValue !== item.value"

--- a/pkg/rancher-ai-ui/components/tools/components/Explore.vue
+++ b/pkg/rancher-ai-ui/components/tools/components/Explore.vue
@@ -169,7 +169,7 @@ onMounted(async() => {
     <RcButton
       v-clean-tooltip="tooltip"
       small
-      tertiary
+      variant="tertiary"
       :disabled="props.disabled"
       @click="navigateToRoute"
     >

--- a/pkg/rancher-ai-ui/components/tools/components/OpenConsoleLogs.vue
+++ b/pkg/rancher-ai-ui/components/tools/components/OpenConsoleLogs.vue
@@ -126,7 +126,7 @@ onMounted(async() => {
   <div v-if="!!pod">
     <RcButton
       small
-      tertiary
+      variant="tertiary"
       :disabled="props.disabled"
       @click="() => openConsoleLogs()"
     >

--- a/pkg/rancher-ai-ui/components/tools/components/ShowYaml.vue
+++ b/pkg/rancher-ai-ui/components/tools/components/ShowYaml.vue
@@ -133,7 +133,7 @@ function emitConfirmationAction(value: boolean) {
     >
       <RcButton
         small
-        tertiary
+        variant="tertiary"
         :disabled="props.disabled"
         @click="navigateToStaging"
       >

--- a/pkg/rancher-ai-ui/components/tools/components/ShowYamlDiff.vue
+++ b/pkg/rancher-ai-ui/components/tools/components/ShowYamlDiff.vue
@@ -135,7 +135,7 @@ function emitConfirmationAction(value: boolean) {
     >
       <RcButton
         small
-        tertiary
+        variant="tertiary"
         :disabled="props.disabled"
         @click="navigateToStaging"
       >

--- a/pkg/rancher-ai-ui/pages/settings/Settings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/Settings.vue
@@ -524,140 +524,146 @@ onMounted(async() => {
 </script>
 
 <template>
-  <loading v-if="isLoading" />
-  <div
-    v-else
-    class="ai-configs-container"
-    data-testid="rancher-ai-ui-settings-container"
-  >
-    <h1 class="m-0">
-      {{ t('aiConfig.form.header') }}
-    </h1>
-
-    <Banner
-      v-if="!permissions?.list?.canListDeployments || !permissions?.list?.canListConfigMaps || !permissions?.list?.canListAiAgentCRDS"
-      class="m-0"
-      color="warning"
+  <div class="ai-configs-container">
+    <loading v-if="isLoading" />
+    <div
+      v-else
+      class="ai-configs"
+      data-testid="rancher-ai-ui-settings-container"
     >
-      <RichTranslation
-        :k="'aiConfig.form.warning.missingPermissions'"
-      >
-        <template #docsUrl="{ content }">
-          <a
-            :href="`${ PERMISSIONS_DOCS_URL }`"
-            tabindex="0"
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-          >
-            {{ content }} <i class="icon icon-external-link" />
-            <span class="sr-only">{{ t('generic.opensInNewTab') }}</span>
-          </a>
-        </template>
-      </RichTranslation>
-    </Banner>
+      <h1 class="m-0">
+        {{ t('aiConfig.form.header') }}
+      </h1>
 
-    <template
-      v-else-if="!aiAgentDeployment || !aiAgentSettings"
+      <Banner
+        v-if="!permissions?.list?.canListDeployments || !permissions?.list?.canListConfigMaps || !permissions?.list?.canListAiAgentCRDS"
+        class="m-0"
+        color="warning"
+      >
+        <RichTranslation
+          :k="'aiConfig.form.warning.missingPermissions'"
+        >
+          <template #docsUrl="{ content }">
+            <a
+              :href="`${ PERMISSIONS_DOCS_URL }`"
+              tabindex="0"
+              target="_blank"
+              rel="noopener noreferrer nofollow"
+            >
+              {{ content }} <i class="icon icon-external-link" />
+              <span class="sr-only">{{ t('generic.opensInNewTab') }}</span>
+            </a>
+          </template>
+        </RichTranslation>
+      </Banner>
+
+      <template
+        v-else-if="!aiAgentDeployment || !aiAgentSettings"
+      >
+        <Banner
+          v-if="!aiAgentDeployment"
+          class="m-0"
+          color="error"
+          :label="t('aiConfig.form.warning.noDeployment')"
+        />
+        <Banner
+          v-if="!aiAgentSettings"
+          class="m-0"
+          color="error"
+          :label="t('aiConfig.form.section.provider.noSecret')"
+        />
+      </template>
+
+      <template v-else>
+        <settings-row
+          :section-id="'ai-agent-settings'"
+          :title="t('aiConfig.form.section.provider.header')"
+          :description="t('aiConfig.form.section.provider.description')"
+          data-testid="rancher-ai-ui-settings-ai-agent-settings"
+        >
+          <AIAgentSettings
+            :value="aiAgentSettings"
+            :read-only="!permissions?.create.canCreateSecrets"
+            @update:value="aiAgentSettings = $event; apiError = ''"
+            @update:validation-error="hasAiAgentSettingsValidationErrors = $event"
+          />
+        </settings-row>
+
+        <settings-row
+          :section-id="'ai-agents-configs'"
+          :title="t('aiConfig.form.section.aiAgent.header')"
+          :description="t('aiConfig.form.section.aiAgent.description')"
+          data-testid="rancher-ai-ui-settings-ai-agent-configs"
+        >
+          <AIAgentConfigs
+            v-if="aiAgentConfigCRDs"
+            :value="aiAgentConfigCRDs"
+            :init-value="initAiAgentConfigCRDs"
+            :read-only="!permissions?.create.canCreateSecrets || !permissions?.create.canCreateAiAgentCRDS"
+            @update:value="aiAgentConfigCRDs = $event"
+            @update:authentication-secrets="authenticationSecrets = $event"
+            @update:validation-error="hasAiAgentConfigsValidationErrors = $event"
+          />
+        </settings-row>
+
+        <settings-row
+          :section-id="'ui-tools-config'"
+          :title="t('aiConfig.form.section.tools.header')"
+          :description="t('aiConfig.form.section.tools.description')"
+          :banner="toolsActionResultBanner"
+          data-testid="rancher-ai-ui-settings-tools"
+        >
+          <UIToolsConfig
+            v-if="uiToolsSettings"
+            :value="uiToolsSettings"
+            :read-only="!permissions?.create.canCreateConfigMaps"
+            :required-action="toolsRequiredAction"
+            @update:value="uiToolsSettings = $event"
+            @publish:tools="publishToolsDefinitionAndRefetch"
+          />
+        </settings-row>
+
+        <Banner
+          v-if="!!apiError"
+          class="m-0"
+          color="error"
+          :label="apiError"
+        />
+
+        <div class="form-footer">
+          <async-button
+            v-if="permissions?.create.canCreateAiAgentCRDS || permissions?.create.canCreateSecrets"
+            action-label="Apply"
+            data-testid="rancher-ai-ui-settings-save-button"
+            :success-label="buttonProps.successLabel"
+            :success-color="buttonProps.successColor"
+            :disabled="hasAiAgentSettingsValidationErrors || hasAiAgentConfigsValidationErrors"
+            @click="applySettingsCb = $event; isSaving = true"
+          />
+        </div>
+      </template>
+    </div>
+    <app-modal
+      v-if="isSaving"
+      :width="400"
+      :click-to-close="false"
+      height="auto"
     >
-      <Banner
-        v-if="!aiAgentDeployment"
-        class="m-0"
-        color="error"
-        :label="t('aiConfig.form.warning.noDeployment')"
+      <ApplySettings
+        :storage-type="chatSettings?.storageType || ''"
+        @confirm="applySettings"
+        @cancel="discardSettings"
       />
-      <Banner
-        v-if="!aiAgentSettings"
-        class="m-0"
-        color="error"
-        :label="t('aiConfig.form.section.provider.noSecret')"
-      />
-    </template>
-
-    <template v-else>
-      <settings-row
-        :section-id="'ai-agent-settings'"
-        :title="t('aiConfig.form.section.provider.header')"
-        :description="t('aiConfig.form.section.provider.description')"
-        data-testid="rancher-ai-ui-settings-ai-agent-settings"
-      >
-        <AIAgentSettings
-          :value="aiAgentSettings"
-          :read-only="!permissions?.create.canCreateSecrets"
-          @update:value="aiAgentSettings = $event; apiError = ''"
-          @update:validation-error="hasAiAgentSettingsValidationErrors = $event"
-        />
-      </settings-row>
-
-      <settings-row
-        :section-id="'ai-agents-configs'"
-        :title="t('aiConfig.form.section.aiAgent.header')"
-        :description="t('aiConfig.form.section.aiAgent.description')"
-        data-testid="rancher-ai-ui-settings-ai-agent-configs"
-      >
-        <AIAgentConfigs
-          v-if="aiAgentConfigCRDs"
-          :value="aiAgentConfigCRDs"
-          :init-value="initAiAgentConfigCRDs"
-          :read-only="!permissions?.create.canCreateSecrets || !permissions?.create.canCreateAiAgentCRDS"
-          @update:value="aiAgentConfigCRDs = $event"
-          @update:authentication-secrets="authenticationSecrets = $event"
-          @update:validation-error="hasAiAgentConfigsValidationErrors = $event"
-        />
-      </settings-row>
-
-      <settings-row
-        :section-id="'ui-tools-config'"
-        :title="t('aiConfig.form.section.tools.header')"
-        :description="t('aiConfig.form.section.tools.description')"
-        :banner="toolsActionResultBanner"
-        data-testid="rancher-ai-ui-settings-tools"
-      >
-        <UIToolsConfig
-          v-if="uiToolsSettings"
-          :value="uiToolsSettings"
-          :read-only="!permissions?.create.canCreateConfigMaps"
-          :required-action="toolsRequiredAction"
-          @update:value="uiToolsSettings = $event"
-          @publish:tools="publishToolsDefinitionAndRefetch"
-        />
-      </settings-row>
-
-      <Banner
-        v-if="!!apiError"
-        class="m-0"
-        color="error"
-        :label="apiError"
-      />
-
-      <div class="form-footer">
-        <async-button
-          v-if="permissions?.create.canCreateAiAgentCRDS || permissions?.create.canCreateSecrets"
-          action-label="Apply"
-          data-testid="rancher-ai-ui-settings-save-button"
-          :success-label="buttonProps.successLabel"
-          :success-color="buttonProps.successColor"
-          :disabled="hasAiAgentSettingsValidationErrors || hasAiAgentConfigsValidationErrors"
-          @click="applySettingsCb = $event; isSaving = true"
-        />
-      </div>
-    </template>
+    </app-modal>
   </div>
-  <app-modal
-    v-if="isSaving"
-    :width="400"
-    :click-to-close="false"
-    height="auto"
-  >
-    <ApplySettings
-      :storage-type="chatSettings?.storageType || ''"
-      @confirm="applySettings"
-      @cancel="discardSettings"
-    />
-  </app-modal>
 </template>
 
 <style lang="scss" scoped>
 .ai-configs-container {
+  display: contents;
+}
+
+.ai-configs {
   display: flex;
   flex-direction: column;
   gap: 24px;

--- a/pkg/rancher-ai-ui/pages/settings/sections/ui-tools-config/Intro.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ui-tools-config/Intro.vue
@@ -65,7 +65,7 @@ const docsUrl = 'https://rancher.github.io/rancher-ai-product-docs/rancher-ai/la
       </Banner>
       <RcButton
         v-if="!props.readOnly"
-        primary
+        variant="primary"
         data-testid="rancher-ai-ui-tools-config-action-button"
         @click="emit('publish:tools')"
       >

--- a/pkg/rancher-ai-ui/pages/settings/sections/ui-tools-config/index.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ui-tools-config/index.vue
@@ -358,7 +358,7 @@ const resetToolsToDefaults = () => {
               <p>{{ t('aiConfig.form.section.tools.tryAdjustingFilters', {}, true) }}</p>
               <RcButton
                 v-if="!noFiltersApplied"
-                tertiary
+                variant="tertiary"
                 class="inline-button"
                 @click="resetAllFilters"
               >

--- a/pkg/rancher-ai-ui/pages/staging/yaml-editor/index.vue
+++ b/pkg/rancher-ai-ui/pages/staging/yaml-editor/index.vue
@@ -105,13 +105,13 @@ watch(patched, (val) => {
         class="staging-yaml-actions"
       >
         <RcButton
-          secondary
+          variant="secondary"
           @click="handleCancel"
         >
           {{ t('ai.staging.yaml-editor.cancel', {}, true) }}
         </RcButton>
         <RcButton
-          primary
+          variant="primary"
           @click="handleApply"
         >
           {{ t('ai.staging.yaml-editor.apply', {}, true) }}
@@ -122,7 +122,7 @@ watch(patched, (val) => {
         class="staging-yaml-actions"
       >
         <RcButton
-          secondary
+          variant="secondary"
           @click="emit('close')"
         >
           {{ t('ai.staging.yaml-editor.close', {}, true) }}


### PR DESCRIPTION
This will fix some deprecations and remove various warnings from the console logs.

- Replace ghost,primary,secondary,tertiary modifiers with `variant={modifier}` syntax
- We are encapsulating some element in a parent div to avoid `extraneous class...` warnings

Note

- We are keeping `size` modifier as is, since `variant="{size}"` changes the style - we have to review the new dimension system with UX before to change it