### PR TITLE
Fix missing resources on multi confirmation

### DIFF
--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -450,7 +450,13 @@ export function useChatMessageComposable(
 
         if (data.startsWith(Tag.McpResultStart) && data.endsWith(Tag.McpResultEnd)) {
           setPhase(MessagePhase.Finalizing);
-          currentMsg.value.relatedResourcesActions = formatMessageRelatedResourcesActions(data);
+
+          const relatedResourcesActions = formatMessageRelatedResourcesActions(data);
+
+          if (!currentMsg.value.relatedResourcesActions) {
+            currentMsg.value.relatedResourcesActions = [];
+          }
+          currentMsg.value.relatedResourcesActions.push(...relatedResourcesActions);
           break;
         }
 


### PR DESCRIPTION
When asking for multiple resources creation, the Agent sends multiple `<mcp-response>` tags, 1 for each resource created.

The UI expects to receive only 1 of those tags per message, so when the next tags are received, the old one is overwritten.

As result of this, the result messages doesn't show the related-resource buttons for all resources involved.

### Proposed solution

- It should simply `append` new mcp-responses.

### Screenshots

Before

https://github.com/user-attachments/assets/135ec0a6-ab51-46d1-8b3f-93f1923c0a78

After


https://github.com/user-attachments/assets/d9d91475-8618-4d7d-ba13-7869f30aa823



