### PR TITLE
Support Custom Headers secrets

### DIFF
--- a/cypress/e2e/po/components/tabbed.po.ts
+++ b/cypress/e2e/po/components/tabbed.po.ts
@@ -1,8 +1,13 @@
+import ComponentPo from '@rancher/cypress/e2e/po/components/component.po';
 import DefaultTabbedPo from '@rancher/cypress/e2e/po/components/tabbed.po';
 
 export default class TabbedPo extends DefaultTabbedPo {
   constructor(selector: string) {
     super(selector);
+  }
+
+  getTabByPrefix(prefix: string) {
+    return new ComponentPo(`[data-testid^="${ prefix }"]`, this.self());
   }
 
   addTab() {

--- a/cypress/e2e/po/dialog/apply-settings.po.ts
+++ b/cypress/e2e/po/dialog/apply-settings.po.ts
@@ -5,7 +5,11 @@ export default class ApplySettingsPromptPo extends ComponentPo {
     super(cy.get('[data-testid="card"].prompt-apply-settings'));
   }
 
+  applyButton() {
+    return this.self().getId('prompt-apply-settings-confirm-button');
+  }
+
   confirm() {
-    return this.self().getId('prompt-apply-settings-confirm-button').click();
+    return this.applyButton().click();
   }
 }

--- a/cypress/e2e/tests/features/settings.spec.ts
+++ b/cypress/e2e/tests/features/settings.spec.ts
@@ -61,6 +61,8 @@ describe('AI Assistant Configuration', () => {
 
       new ApplySettingsPromptPo().confirm();
 
+      settingsPage.settings().saveButton().should('contain.text', 'Saved');
+
       // Revisit the page to check if the settings were saved correctly
       settingsPage.goTo();
       settingsPage.waitForPage();
@@ -77,6 +79,8 @@ describe('AI Assistant Configuration', () => {
       settingsPage.settings().saveButton().click();
 
       new ApplySettingsPromptPo().confirm();
+
+      settingsPage.settings().saveButton().should('contain.text', 'Saved');
     });
   });
 
@@ -123,6 +127,8 @@ describe('AI Assistant Configuration', () => {
 
       new ApplySettingsPromptPo().confirm();
 
+      settingsPage.settings().saveButton().should('contain.text', 'Saved');
+
       // Check that the new agent tab is showing error status due to invalid MCP URL
       aiAgentConfigs.tabs().assertTabHasLabelIcon(`[data-testid^="${ updatedValues.customAgentPrefix }"]`, 'icon-error');
 
@@ -144,6 +150,8 @@ describe('AI Assistant Configuration', () => {
       settingsPage.settings().saveButton().click();
 
       new ApplySettingsPromptPo().confirm();
+
+      settingsPage.settings().saveButton().should('contain.text', 'Saved');
 
       // Revisit the page to check if the settings were saved correctly
       settingsPage.goTo();

--- a/cypress/e2e/tests/features/settings.spec.ts
+++ b/cypress/e2e/tests/features/settings.spec.ts
@@ -14,9 +14,9 @@ describe('AI Assistant Configuration', () => {
   };
 
   const updatedValues = {
-    llm:         'gemini',
-    apiKey:      'my-api-key',
-    customAgent: 'agent-4'
+    llm:               'gemini',
+    apiKey:            'my-api-key',
+    customAgentPrefix: 'agent-4-'
   };
 
   beforeEach(() => {
@@ -104,9 +104,9 @@ describe('AI Assistant Configuration', () => {
       // Add a custom AI Agent
       aiAgentConfigs.tabs().addTab();
 
-      aiAgentConfigs.tabs().getTab(updatedValues.customAgent).checkExists();
+      aiAgentConfigs.tabs().getTabByPrefix(updatedValues.customAgentPrefix).checkExists();
 
-      aiAgentConfigs.tabs().assertTabIsActive(`[data-testid="${ updatedValues.customAgent }"]`);
+      aiAgentConfigs.tabs().assertTabIsActive(`[data-testid^="${ updatedValues.customAgentPrefix }"]`);
       aiAgentConfigs.self().should('not.contain', 'This AI agent is locked');
 
       // Check that Save button is disabled since the new agent has validation errors -> missing MCP URL
@@ -124,22 +124,22 @@ describe('AI Assistant Configuration', () => {
       new ApplySettingsPromptPo().confirm();
 
       // Check that the new agent tab is showing error status due to invalid MCP URL
-      aiAgentConfigs.tabs().assertTabHasLabelIcon(`[data-testid="${ updatedValues.customAgent }"]`, 'icon-error');
+      aiAgentConfigs.tabs().assertTabHasLabelIcon(`[data-testid^="${ updatedValues.customAgentPrefix }"]`, 'icon-error');
 
       // Revisit the page to check if the settings were saved correctly
       settingsPage.goTo();
       settingsPage.waitForPage();
 
-      aiAgentConfigs.tabs().assertTabIsActive(`[data-testid="${ updatedValues.customAgent }"]`);
+      aiAgentConfigs.tabs().assertTabIsActive(`[data-testid^="${ updatedValues.customAgentPrefix }"]`);
       aiAgentConfigs.mcpUrlInput().value().should('eq', 'http://my-mcp-url:8080');
 
       // Check that the new agent tab is showing error status due to invalid MCP URL
-      aiAgentConfigs.tabs().assertTabHasLabelIcon(`[data-testid="${ updatedValues.customAgent }"]`, 'icon-error');
+      aiAgentConfigs.tabs().assertTabHasLabelIcon(`[data-testid^="${ updatedValues.customAgentPrefix }"]`, 'icon-error');
 
       // Remove the custom AI Agent
       aiAgentConfigs.tabs().removeTab();
 
-      aiAgentConfigs.tabs().getTab(updatedValues.customAgent).checkNotExists();
+      aiAgentConfigs.tabs().getTabByPrefix(updatedValues.customAgentPrefix).checkNotExists();
 
       settingsPage.settings().saveButton().click();
 
@@ -149,7 +149,7 @@ describe('AI Assistant Configuration', () => {
       settingsPage.goTo();
       settingsPage.waitForPage();
 
-      aiAgentConfigs.tabs().getTab(updatedValues.customAgent).checkNotExists();
+      aiAgentConfigs.tabs().getTabByPrefix(updatedValues.customAgentPrefix).checkNotExists();
       aiAgentConfigs.tabs().assertTabIsActive(`[data-testid="${ initValues.rancherAgent }"]`);
     });
   });

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -352,6 +352,7 @@ aiConfig:
               none: No authentication
               basic: Basic authentication
               rancher: Rancher authentication
+              header: Custom Headers authentication
           
     EMBEDDINGS_MODEL:
       label: Embeddings Model

--- a/pkg/rancher-ai-ui/pages/settings/Settings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/Settings.vue
@@ -239,7 +239,7 @@ async function saveAiAgentConfigCRDs() {
     }
 
     // Normalize authenticationSecret
-    if (aiAgentConfigCRD.spec.authenticationType === AIAgentConfigAuthType.BASIC) {
+    if (aiAgentConfigCRD.spec.authenticationType === AIAgentConfigAuthType.BASIC || aiAgentConfigCRD.spec.authenticationType === AIAgentConfigAuthType.HEADER) {
       aiAgentConfigCRD.spec.authenticationSecret = aiAgentConfigCRD.spec.authenticationSecret?.replaceAll(`${ AGENT_NAMESPACE }/`, '');
     } else {
       delete aiAgentConfigCRD.spec.authenticationSecret;

--- a/pkg/rancher-ai-ui/pages/settings/Settings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/Settings.vue
@@ -49,8 +49,11 @@ const applySettingsCb = ref<AsyncButtonCallback | null>(null);
 
 const aiAgentDeployment = ref<Workload | null>(null);
 const chatSettings = ref<AgentSettings | null>(null);
+
 const aiAgentSettings = ref<SettingsFormData | null>(null);
+
 const aiAgentConfigCRDs = ref<AIAgentConfigCRD[] | null>(null);
+const initAiAgentConfigCRDs = ref<AIAgentConfigCRD[]>([]);
 const authenticationSecrets = ref<Record<string, AiAgentConfigSecretPayload | null>>({});
 
 const permissions = ref<SettingsPermissions | null>(null);
@@ -153,6 +156,7 @@ async function fetchAiAgentConfigCRDs() {
   }
 
   aiAgentConfigCRDs.value = crds;
+  initAiAgentConfigCRDs.value = [...crds];
 }
 
 /**
@@ -251,6 +255,8 @@ async function saveAiAgentConfigCRDs() {
       warn(`Unable to create AI Agent Config CRD ${ crd.metadata.name }: `, { err });
     }
   }
+
+  initAiAgentConfigCRDs.value = [...crdsToSave];
 }
 
 /**
@@ -491,6 +497,7 @@ onMounted(async() => {
         <AIAgentConfigs
           v-if="aiAgentConfigCRDs"
           :value="aiAgentConfigCRDs"
+          :init-value="initAiAgentConfigCRDs"
           :read-only="!permissions?.create.canCreateSecrets || !permissions?.create.canCreateAiAgentCRDS"
           @update:value="aiAgentConfigCRDs = $event"
           @update:authentication-secrets="authenticationSecrets = $event"

--- a/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
@@ -14,6 +14,7 @@ import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import Banner from '@components/Banner/Banner.vue';
 import TextAreaAutoGrow from '@components/Form/TextArea/TextAreaAutoGrow.vue';
 import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthSecret.vue';
+import SecretSelector from '@shell/components/form/SecretSelector.vue';
 import FileSelector from '@shell/components/form/FileSelector.vue';
 import formRulesGenerator from '@shell/utils/validators/formRules';
 
@@ -47,6 +48,10 @@ const authOptions = [
     value: AIAgentConfigAuthType.BASIC
   },
   {
+    label: t('aiConfig.form.section.aiAgent.options.mcp.authOptions.header'),
+    value: AIAgentConfigAuthType.HEADER
+  },
+  {
     label: t('aiConfig.form.section.aiAgent.options.mcp.authOptions.rancher'),
     value: AIAgentConfigAuthType.RANCHER
   },
@@ -55,6 +60,8 @@ const authOptions = [
     value: AIAgentConfigAuthType.NONE
   }
 ];
+
+const initAgents = [...props.value];
 
 const agents = computed(() => {
   /**
@@ -148,7 +155,35 @@ function tabLabelIcon(agent: AIAgentConfigCRD) {
   return 'icon-close';
 }
 
-function updateAuthenticationSecret(value: AiAgentConfigSecretPayload) {
+function updateAuthType(value: AIAgentConfigAuthType) {
+  const updatedSpecValue = {
+    spec: {
+      ...selectedAgent.value.spec,
+      authenticationType: value
+    }
+  };
+
+  const initAgent = initAgents.find((a) => a.metadata?.name === selectedAgentName.value);
+
+  if (updatedSpecValue.spec.authenticationType !== initAgent?.spec.authenticationType) {
+    // When the authentication type changes, we need to clear the authentication secret live value
+    updatedSpecValue.spec.authenticationSecret = undefined;
+  } else {
+    // Else keep the initial value
+    updatedSpecValue.spec.authenticationSecret = initAgent?.spec.authenticationSecret;
+  }
+
+  updateAgent(updatedSpecValue);
+
+  // Cleaning up the agentSecrets to avoid creating new secrets when the type is not BASIC
+  if (updatedSpecValue.spec.authenticationType !== AIAgentConfigAuthType.BASIC) {
+    delete agentSecrets.value[selectedAgentName.value];
+
+    emit('update:authentication-secrets', undefined);
+  }
+}
+
+function updateBasicAuthSecret(value: AiAgentConfigSecretPayload) {
   const { selected, privateKey, publicKey } = value;
 
   // Clear the authenticationSecret fields
@@ -416,7 +451,7 @@ watch(validationErrors, (errors) => {
                 :disabled="isAgentLocked || props.readOnly"
                 :label="t('aiConfig.form.section.aiAgent.fields.authenticationType.label')"
                 :options="authOptions"
-                @update:value="(val: AIAgentConfigAuthType) => updateAgent({ spec: { ...selectedAgent.spec, authenticationType: val } })"
+                @update:value="updateAuthType"
               />
             </div>
           </div>
@@ -436,7 +471,20 @@ watch(validationErrors, (errors) => {
                 :register-before-hook="() => {}"
                 in-store="management"
                 label-key="aiConfig.form.section.aiAgent.fields.authenticationSecret.label"
-                @inputauthval="updateAuthenticationSecret"
+                @inputauthval="updateBasicAuthSecret"
+              />
+            </div>
+          </div>
+          <div
+            v-else-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.HEADER && !isAgentLocked && !props.readOnly"
+            class="row"
+          >
+            <div class="col span-6">
+              <SecretSelector
+                :value="selectedAgent.spec.authenticationSecret || undefined"
+                :secret-name-label="t('aiConfig.form.section.aiAgent.fields.authenticationSecret.label')"
+                :namespace="AGENT_NAMESPACE"
+                @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, authenticationSecret: value || undefined } })"
               />
             </div>
           </div>

--- a/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
@@ -2,6 +2,7 @@
 import { ref, computed, PropType, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
+import { randomStr } from '@shell/utils/string';
 import { AGENT_NAMESPACE } from '../../../product';
 import { AIAgentConfigCRD } from '../../../types';
 import { AIAgentConfigAuthType, AiAgentConfigSecretPayload } from '../types';
@@ -79,7 +80,9 @@ const agents = computed(() => {
   const builtIn = all
     .filter((a) => a.spec.builtIn)
     .sort((a) => a.metadata.name === DEFAULT_AI_AGENT ? -1 : 1);
-  const custom = all.filter((a) => !a.spec.builtIn);
+  const custom = all
+    .filter((a) => !a.spec.builtIn)
+    .sort((a, b) => b.metadata.name.localeCompare(a.metadata.name));
 
   return [
     ...custom,
@@ -246,7 +249,10 @@ function addAgent() {
     return;
   }
 
-  const name = `agent-${ agents.value.length + 1 }`;
+  // Random string is added to ensure the name is unique even when multiple agents are being added without saving in between
+  const name = `agent-${ agents.value.length + 1 }-${ randomStr(8) }`.toLocaleLowerCase();
+
+  const newAgentsCount = agents.value.filter((a) => a.spec?.displayName?.trim().startsWith('New Agent')).length;
 
   const newList: AIAgentConfigCRD[] = [
     {
@@ -255,7 +261,7 @@ function addAgent() {
         namespace: AGENT_NAMESPACE
       },
       spec:     {
-        displayName:          'New Agent',
+        displayName:          `New Agent${ newAgentsCount === 0 ? '' : ` ${ newAgentsCount }` }`,
         enabled:              true,
         mcpURL:               '',
         authenticationType:   AIAgentConfigAuthType.RANCHER,

--- a/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
@@ -30,6 +30,10 @@ const props = defineProps({
     type:     Array as PropType<AIAgentConfigCRD[]>,
     default:  () => [],
   },
+  initValue: {
+    type:     Array as PropType<AIAgentConfigCRD[]>,
+    default:  () => [],
+  },
   readOnly: {
     type:    Boolean,
     default: false,
@@ -60,8 +64,6 @@ const authOptions = [
     value: AIAgentConfigAuthType.NONE
   }
 ];
-
-const initAgents = [...props.value];
 
 const agents = computed(() => {
   /**
@@ -163,7 +165,7 @@ function updateAuthType(value: AIAgentConfigAuthType) {
     }
   };
 
-  const initAgent = initAgents.find((a) => a.metadata?.name === selectedAgentName.value);
+  const initAgent = props.initValue.find((a) => a.metadata?.name === selectedAgentName.value);
 
   if (updatedSpecValue.spec.authenticationType !== initAgent?.spec.authenticationType) {
     // When the authentication type changes, we need to clear the authentication secret live value

--- a/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
@@ -1866,7 +1866,7 @@ describe('AIAgentConfigs.vue', () => {
         expect(vm.agentSecrets['test-agent']).toBeUndefined();
       });
 
-      it('should emit update:authentication-secrets event with agentSecrets when changing to non-BASIC auth', () => {
+      it('should emit undefined for update:authentication-secrets when changing away from BASIC auth', () => {
         const agent = mockAgent({
           spec: {
             ...mockAgent().spec,
@@ -1889,32 +1889,7 @@ describe('AIAgentConfigs.vue', () => {
         const emitted = wrapper.emitted('update:authentication-secrets');
 
         expect(emitted).toBeTruthy();
-        // When changing away from BASIC, the event should be emitted (with undefined since agentSecrets was deleted)
-        expect(emitted![0][0]).toBe(undefined);
-      });
-
-      it('should not emit undefined for update:authentication-secrets when changing to HEADER', () => {
-        const agent = mockAgent({
-          spec: {
-            ...mockAgent().spec,
-            authenticationType: AIAgentConfigAuthType.RANCHER
-          }
-        });
-
-        const wrapper = shallowMount(AIAgentConfigs, {
-          ...requiredSetup(),
-          props: { value: [agent] }
-        });
-
-        const vm = wrapper.vm as any;
-
-        // No secrets stored
-        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
-
-        const emitted = wrapper.emitted('update:authentication-secrets');
-
-        expect(emitted).toBeTruthy();
-        // Should emit undefined since we're not in BASIC mode
+        // When changing away from BASIC, the event should be emitted with undefined (since agentSecrets was deleted)
         expect(emitted![0][0]).toBe(undefined);
       });
     });

--- a/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
@@ -629,7 +629,7 @@ describe('AIAgentConfigs.vue', () => {
 
       const vm = wrapper.vm as any;
 
-      vm.updateAuthenticationSecret({ selected: '_none' });
+      vm.updateBasicAuthSecret({ selected: '_none' });
 
       const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
 
@@ -650,7 +650,7 @@ describe('AIAgentConfigs.vue', () => {
         publicKey:  'pubk-value'
       };
 
-      vm.updateAuthenticationSecret(secretPayload);
+      vm.updateBasicAuthSecret(secretPayload);
 
       expect(vm.agentSecrets['test-agent']).toEqual(secretPayload);
     });
@@ -663,7 +663,7 @@ describe('AIAgentConfigs.vue', () => {
 
       const vm = wrapper.vm as any;
 
-      vm.updateAuthenticationSecret({ selected: 'existing-secret' });
+      vm.updateBasicAuthSecret({ selected: 'existing-secret' });
 
       const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
 
@@ -678,7 +678,7 @@ describe('AIAgentConfigs.vue', () => {
 
       const vm = wrapper.vm as any;
 
-      vm.updateAuthenticationSecret({ selected: '_none' });
+      vm.updateBasicAuthSecret({ selected: '_none' });
 
       const emitted = wrapper.emitted('update:authentication-secrets');
 
@@ -696,7 +696,7 @@ describe('AIAgentConfigs.vue', () => {
 
       vm.agentSecrets['test-agent'] = { selected: '_basic' };
 
-      vm.updateAuthenticationSecret({ selected: 'secret-name' });
+      vm.updateBasicAuthSecret({ selected: 'secret-name' });
 
       expect(vm.agentSecrets['test-agent']).toBeUndefined();
     });
@@ -1240,14 +1240,14 @@ describe('AIAgentConfigs.vue', () => {
       const vm = wrapper.vm as any;
 
       vm.selectedAgentName = 'agent-1';
-      vm.updateAuthenticationSecret({
+      vm.updateBasicAuthSecret({
         selected:   '_basic',
         privateKey: 'pk1',
         publicKey:  'pubk1'
       });
 
       vm.selectedAgentName = 'agent-2';
-      vm.updateAuthenticationSecret({
+      vm.updateBasicAuthSecret({
         selected:   '_basic',
         privateKey: 'pk2',
         publicKey:  'pubk2'
@@ -1734,6 +1734,420 @@ describe('AIAgentConfigs.vue', () => {
       const selectAuth = wrapper.findComponent({ name: 'SelectOrCreateAuthSecret' });
 
       expect(selectAuth.exists()).toBe(false);
+    });
+  });
+
+  describe('Authentication Type', () => {
+    describe('HEADER Auth Type', () => {
+      it('should change auth type to HEADER', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.RANCHER
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+      });
+
+      it('should clear authenticationSecret when changing from RANCHER to HEADER', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType:   AIAgentConfigAuthType.RANCHER,
+            authenticationSecret: undefined
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // Update to HEADER type
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+        expect(emitted[0].spec.authenticationSecret).toBeUndefined();
+      });
+
+      it('should clear authenticationSecret when changing from BASIC to HEADER', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType:   AIAgentConfigAuthType.BASIC,
+            authenticationSecret: 'basic-secret'
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+        expect(emitted[0].spec.authenticationSecret).toBeUndefined();
+      });
+
+      it('should preserve authenticationSecret when changing to same HEADER type with initial secret', () => {
+        const initAgent = mockAgent({
+          metadata: {
+            name:      'test-agent',
+            namespace: 'ai-agent'
+          },
+          spec: {
+            ...mockAgent().spec,
+            authenticationType:   AIAgentConfigAuthType.HEADER,
+            authenticationSecret: 'header-secret'
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [initAgent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // Change to same type (should preserve)
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationSecret).toBe('header-secret');
+      });
+
+      it('should clean up agentSecrets when changing to HEADER type', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.BASIC
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // Store a secret for this agent
+        vm.agentSecrets['test-agent'] = {
+          selected:   '_basic',
+          privateKey: 'pk',
+          publicKey:  'pubk'
+        };
+
+        // Change to HEADER (should clean up agentSecrets)
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        expect(vm.agentSecrets['test-agent']).toBeUndefined();
+      });
+
+      it('should emit update:authentication-secrets event with agentSecrets when changing to non-BASIC auth', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.BASIC
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        vm.agentSecrets['test-agent'] = { selected: '_basic' };
+
+        // Change to HEADER, which is not BASIC
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        const emitted = wrapper.emitted('update:authentication-secrets');
+
+        expect(emitted).toBeTruthy();
+        // When changing away from BASIC, the event should be emitted (with undefined since agentSecrets was deleted)
+        expect(emitted![0][0]).toBe(undefined);
+      });
+
+      it('should not emit undefined for update:authentication-secrets when changing to HEADER', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.RANCHER
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // No secrets stored
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        const emitted = wrapper.emitted('update:authentication-secrets');
+
+        expect(emitted).toBeTruthy();
+        // Should emit undefined since we're not in BASIC mode
+        expect(emitted![0][0]).toBe(undefined);
+      });
+    });
+
+    describe('HEADER Auth Type with SecretSelector', () => {
+      it('should use SecretSelector when HEADER auth is selected', async() => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.HEADER
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // HEADER type should not use SelectOrCreateAuthSecret (which is for BASIC)
+        expect(vm.selectedAgent.spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+        // SelectOrCreateAuthSecret should not be rendered for HEADER
+        const selectOrCreate = wrapper.findComponent({ name: 'SelectOrCreateAuthSecret' });
+
+        expect(selectOrCreate.exists()).toBe(false);
+      });
+
+      it('should render SecretSelector component when HEADER auth is used', async() => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType:   AIAgentConfigAuthType.HEADER,
+            authenticationSecret: 'header-secret'
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // Verify HEADER auth type is set
+        expect(vm.selectedAgent.spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+        // Verify authentication secret is stored
+        expect(vm.selectedAgent.spec.authenticationSecret).toBe('header-secret');
+      });
+
+      it('should not render SelectOrCreateAuthSecret when HEADER auth is selected', async() => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.HEADER
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const selectOrCreate = wrapper.findComponent({ name: 'SelectOrCreateAuthSecret' });
+
+        expect(selectOrCreate.exists()).toBe(false);
+      });
+    });
+
+    describe('Auth Type Transitions', () => {
+      it('should handle transition from BASIC to HEADER to NONE', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType:   AIAgentConfigAuthType.BASIC,
+            authenticationSecret: 'basic-secret'
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        vm.agentSecrets['test-agent'] = {
+          selected:   '_basic',
+          privateKey: 'pk',
+          publicKey:  'pubk'
+        };
+
+        // Change to HEADER
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        let emitted = wrapper.emitted('update:value')?.[wrapper.emitted('update:value')!.length - 1][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+        expect(emitted[0].spec.authenticationSecret).toBeUndefined();
+        expect(vm.agentSecrets['test-agent']).toBeUndefined();
+
+        // Change to NONE
+        vm.updateAuthType(AIAgentConfigAuthType.NONE);
+
+        emitted = wrapper.emitted('update:value')?.[wrapper.emitted('update:value')!.length - 1][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.NONE);
+        expect(emitted[0].spec.authenticationSecret).toBeUndefined();
+      });
+
+      it('should preserve authentication secret when toggling between HEADER and other types', () => {
+        const initAgent = mockAgent({
+          metadata: {
+            name:      'test-agent',
+            namespace: 'ai-agent'
+          },
+          spec: {
+            ...mockAgent().spec,
+            authenticationType:   AIAgentConfigAuthType.HEADER,
+            authenticationSecret: 'header-secret'
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [initAgent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // Change to RANCHER (should clear since it's different)
+        vm.updateAuthType(AIAgentConfigAuthType.RANCHER);
+
+        let emitted = wrapper.emitted('update:value')?.[wrapper.emitted('update:value')!.length - 1][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationSecret).toBeUndefined();
+
+        // Revert back to HEADER (should restore from init)
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        emitted = wrapper.emitted('update:value')?.[wrapper.emitted('update:value')!.length - 1][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationSecret).toBe('header-secret');
+      });
+    });
+
+    describe('HEADER Auth Type Edge Cases', () => {
+      it('should handle HEADER auth type for multiple agents independently', async() => {
+        const agent1 = mockAgent({
+          metadata: {
+            name:      'agent-1',
+            namespace: 'ai-agent'
+          },
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.RANCHER
+          }
+        });
+
+        const agent2 = mockAgent({
+          metadata: {
+            name:      'agent-2',
+            namespace: 'ai-agent'
+          },
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.BASIC
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent1, agent2] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // Switch to agent-1 and change to HEADER
+        vm.selectedAgentName = 'agent-1';
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        let updateEvents = wrapper.emitted('update:value');
+        let lastEmitted = updateEvents![updateEvents!.length - 1][0] as AIAgentConfigCRD[];
+
+        // Verify agent-1 changed to HEADER
+        expect(lastEmitted.find((a) => a.metadata.name === 'agent-1')?.spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+        expect(lastEmitted.find((a) => a.metadata.name === 'agent-2')?.spec.authenticationType).toBe(AIAgentConfigAuthType.BASIC);
+
+        // Update props with new state
+        await wrapper.setProps({ value: lastEmitted });
+
+        // Now switch to agent-2 and change to HEADER
+        vm.selectedAgentName = 'agent-2';
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        updateEvents = wrapper.emitted('update:value');
+        lastEmitted = updateEvents![updateEvents!.length - 1][0] as AIAgentConfigCRD[];
+
+        // Now both should be HEADER
+        expect(lastEmitted.find((a) => a.metadata.name === 'agent-1')?.spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+        expect(lastEmitted.find((a) => a.metadata.name === 'agent-2')?.spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+      });
+
+      it('should not affect other agent properties when changing to HEADER auth', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            displayName:          'Important Agent',
+            description:          'Important Description',
+            systemPrompt:         'Important Prompt',
+            humanValidationTools: ['tool1', 'tool2'],
+            authenticationType:   AIAgentConfigAuthType.BASIC
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        vm.updateAuthType(AIAgentConfigAuthType.HEADER);
+
+        const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.displayName).toBe('Important Agent');
+        expect(emitted[0].spec.description).toBe('Important Description');
+        expect(emitted[0].spec.systemPrompt).toBe('Important Prompt');
+        expect(emitted[0].spec.humanValidationTools).toEqual(['tool1', 'tool2']);
+      });
     });
   });
 });

--- a/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
@@ -109,8 +109,8 @@ describe('AIAgentConfigs.vue', () => {
 
       const vm = wrapper.vm as any;
 
-      expect(vm.agents[0].metadata.name).toBe('custom-1');
-      expect(vm.agents[1].metadata.name).toBe('custom-2');
+      expect(vm.agents[0].metadata.name).toBe('custom-2');
+      expect(vm.agents[1].metadata.name).toBe('custom-1');
       expect(vm.agents[2].metadata.name).toBe(DEFAULT_AI_AGENT);
     });
 
@@ -309,11 +309,11 @@ describe('AIAgentConfigs.vue', () => {
 
       const vm = wrapper.vm as any;
 
-      expect(vm.selectedAgent.metadata.name).toBe('agent-1');
-
-      vm.tabChanged({ selectedName: 'agent-2' });
-
       expect(vm.selectedAgent.metadata.name).toBe('agent-2');
+
+      vm.tabChanged({ selectedName: 'agent-1' });
+
+      expect(vm.selectedAgent.metadata.name).toBe('agent-1');
     });
   });
 
@@ -354,6 +354,25 @@ describe('AIAgentConfigs.vue', () => {
       expect(newAgent.spec.authenticationType).toBe(AIAgentConfigAuthType.RANCHER);
       expect(newAgent.spec.humanValidationTools).toEqual([]);
       expect(newAgent.spec.mcpURL).toBe('');
+    });
+
+    it('should add new custom agent with correct name format', () => {
+      const wrapper = shallowMount(AIAgentConfigs, {
+        ...requiredSetup(),
+        props: { value: [mockBuiltInAgent()] }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.addAgent();
+
+      const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+      const newAgent = emitted[0];
+
+      // Name should be in format: agent-{count}-{randomString} in lowercase
+      expect(newAgent.metadata.name).toMatch(/^agent-\d+-[a-z0-9]+$/);
+      // The count is based on agents.value.length + 1, which is 2 (1 builtIn agent already exists)
+      expect(newAgent.metadata.name).toMatch(/^agent-2-/);
     });
   });
 
@@ -431,10 +450,14 @@ describe('AIAgentConfigs.vue', () => {
 
       const vm = wrapper.vm as any;
 
+      // After sorting, agents are ordered: agent-2, agent-1, rancher
+      // Select agent-1 (which is at index 1)
       vm.selectedAgentName = 'agent-1';
       vm.removeAgent();
 
-      expect(vm.selectedAgentName).toBe(agent2.metadata.name);
+      // After removal, the next agent in the list should be selected
+      // Since agents are sorted descending, after removing agent-1, the default (rancher) should be selected
+      expect(vm.selectedAgentName).toBe(DEFAULT_AI_AGENT);
     });
 
     it('should clear secrets for removed agent', () => {
@@ -1825,7 +1848,10 @@ describe('AIAgentConfigs.vue', () => {
 
         const wrapper = shallowMount(AIAgentConfigs, {
           ...requiredSetup(),
-          props: { value: [initAgent] }
+          props: {
+            value:     [initAgent],
+            initValue: [initAgent]
+          }
         });
 
         const vm = wrapper.vm as any;
@@ -2017,7 +2043,10 @@ describe('AIAgentConfigs.vue', () => {
 
         const wrapper = shallowMount(AIAgentConfigs, {
           ...requiredSetup(),
-          props: { value: [initAgent] }
+          props: {
+            value:     [initAgent],
+            initValue: [initAgent]
+          }
         });
 
         const vm = wrapper.vm as any;

--- a/pkg/rancher-ai-ui/pages/settings/types.ts
+++ b/pkg/rancher-ai-ui/pages/settings/types.ts
@@ -58,7 +58,8 @@ export interface Workload {
 export const enum AIAgentConfigAuthType {
   NONE = 'NONE',
   RANCHER = 'RANCHER',
-  BASIC = 'BASIC'
+  BASIC = 'BASIC',
+  HEADER = 'HEADER',
 }
 
 export interface AiAgentConfigSecretPayload {


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-ui/issues/188
Related PR https://github.com/rancher/rancher-ai-agent/pull/183

Liz now supports a new header authentication type for the Agents configs.
When set, the agent factory loads custom HTTP headers from the authenticationSecret and passes them to the MCP client connection.

We are adding the new `HEADER` type to support the authentication secret selection

- When the new type is selected, we can select a secret, we don't want inline creation for those secrets
- When switching from HEADER to BASIC and viceversa, we clean up the basic secrets queue and restore the original secret value


https://github.com/user-attachments/assets/8d171f50-e8e3-4973-aed4-353d0cb96c39

