### PR TITLE
Support MCP's Oauth2

### DIFF
--- a/cypress/e2e/po/chat.po.ts
+++ b/cypress/e2e/po/chat.po.ts
@@ -2,6 +2,7 @@ import ComponentPo from '@rancher/cypress/e2e/po/components/component.po';
 import RancherHeaderPo from '@/cypress/e2e/po/components/rancher-header.po';
 import { HeaderPo } from '@/cypress/e2e/po/header.po';
 import { ConsolePo } from '@/cypress/e2e/po/console.po';
+import ContextPo from '@/cypress/e2e/po/context.po';
 import MessagesPo from '@/cypress/e2e/po/messages.po';
 
 export default class ChatPo extends ComponentPo {
@@ -13,7 +14,11 @@ export default class ChatPo extends ComponentPo {
   }
 
   processingState(label?: string) {
-    return this.messagesPanel().processingState(label);
+    if (label) {
+      return this.self().get(`[data-testid="rancher-ai-ui-processing-connection-state-${ label.toLowerCase().replace(/\s/g, '-') }"]`);
+    }
+
+    return this.self().get('[data-testid^="rancher-ai-ui-processing-connection-state-"]');
   }
 
   header() {
@@ -22,6 +27,10 @@ export default class ChatPo extends ComponentPo {
 
   messagesPanel() {
     return new MessagesPo();
+  }
+
+  context() {
+    return new ContextPo();
   }
 
   console() {

--- a/cypress/e2e/po/console.po.ts
+++ b/cypress/e2e/po/console.po.ts
@@ -37,6 +37,10 @@ export class ConsolePo extends ComponentPo {
     super('[data-testid="rancher-ai-ui-chat-console"]');
   }
 
+  isNotDisabled() {
+    return this.self().should('not.have.class', 'disabled-panel');
+  }
+
   textarea() {
     return this.self().get('textarea[data-testid="rancher-ai-ui-chat-input-textarea"]');
   }

--- a/cypress/e2e/po/context.po.ts
+++ b/cypress/e2e/po/context.po.ts
@@ -60,4 +60,8 @@ export default class ContextPo extends ComponentPo {
   isDisabled() {
     return this.self().should('have.class', 'disabled-panel');
   }
+
+  isNotDisabled() {
+    return this.self().should('not.have.class', 'disabled-panel');
+  }
 }

--- a/cypress/e2e/po/messages.po.ts
+++ b/cypress/e2e/po/messages.po.ts
@@ -8,10 +8,10 @@ export default class MessagesPo extends ComponentPo {
 
   processingState(label?: string) {
     if (label) {
-      return this.self().get(`[data-testid="rancher-ai-ui-processing-state-${ label.toLowerCase().replace(/\s/g, '-') }"]`);
+      return this.self().get(`[data-testid="rancher-ai-ui-processing-message-state-${ label.toLowerCase().replace(/\s/g, '-') }"]`);
     }
 
-    return this.self().get('[data-testid^="rancher-ai-ui-processing-state-"]');
+    return this.self().get('[data-testid^="rancher-ai-ui-processing-message-state-"]');
   }
 
   scrollButton() {

--- a/cypress/e2e/po/settings.po.ts
+++ b/cypress/e2e/po/settings.po.ts
@@ -4,6 +4,7 @@ import { ToggleGroupPo } from './components/toggle-group.po';
 import TabbedPo from './components/tabbed.po';
 import CheckboxInputPo from '@rancher/cypress/e2e/po/components/checkbox-input.po';
 import LabeledInputPo from '@rancher/cypress/e2e/po/components/labeled-input.po';
+import LabeledSelectPo from '@rancher/cypress/e2e/po/components/labeled-select.po';
 
 export class SettingsPagePo extends PagePo {
   private static createPath() {
@@ -78,6 +79,43 @@ export class AiAgentConfigs extends ComponentPo {
 
   guidelinesInput() {
     return cy.get('textarea[data-testid="rancher-ai-ui-settings-ai-agent-configs-system-prompt"]').first();
+  }
+
+  // Oauth2 form fields
+  authenticationTypeSelector() {
+    return LabeledSelectPo.byLabel(this.self(), 'Type');
+  }
+
+  metadataEndpointInput() {
+    return LabeledInputPo.byLabel(this.self(), 'Metadata endpoint');
+  }
+
+  scopesSelector() {
+    return LabeledSelectPo.byLabel(this.self(), 'Scopes');
+  }
+
+  scopesInput() {
+    return LabeledInputPo.byLabel(this.self(), 'Scopes');
+  }
+
+  clientIdInput() {
+    return LabeledInputPo.byLabel(this.self(), 'Client ID');
+  }
+
+  clientSecretInput() {
+    return LabeledInputPo.byLabel(this.self(), 'Client Secret');
+  }
+
+  metadataDiscoveryButton() {
+    const key = 'aiConfig.form.section.aiAgent.fields.oauth2.metadata.discoverInfo';
+
+    return this.self().get(`[data-testid="rancher-ai-ui-discovery-banner-button-${ key }"]`);
+  }
+
+  clientInfoDiscoveryButton() {
+    const key = 'aiConfig.form.section.aiAgent.fields.oauth2.client.discoverInfo';
+
+    return this.self().get(`[data-testid="rancher-ai-ui-discovery-banner-button-${ key }"]`);
   }
 }
 

--- a/cypress/e2e/tests/features/chat.spec.ts
+++ b/cypress/e2e/tests/features/chat.spec.ts
@@ -11,7 +11,6 @@ import ChatPo from '@/cypress/e2e/po/chat.po';
 import { HistoryPo } from '@/cypress/e2e/po/history.po';
 import RancherHeaderPo from '@/cypress/e2e/po/components/rancher-header.po';
 import { SlidingBadgePo } from '@/cypress/e2e/po/hook.po';
-import ContextPo from '@/cypress/e2e/po/context.po';
 import RancherSettingsBannersPo from '@/cypress/e2e/po/components/rancher-settings-banners.po';
 import ApplySettingsPromptPo from '@/cypress/e2e/po/dialog/apply-settings.po';
 import { rancherAgentConfig, fleetAgentConfig, provisioningAgentConfig } from '@/cypress/e2e/blueprints/aiAgentConfigs';
@@ -91,9 +90,125 @@ describe('Chat', () => {
     });
   });
 
-  describe('Disconnections handling', () => {
+  describe('Connection and Processing labels', () => {
+    before(() => {
+      cy.login();
+      cy.cleanChatHistory();
+      cy.clearLLMResponses();
+    });
+
     beforeEach(() => {
       cy.login();
+    });
+
+    it('It should become ready when chat is initialized', () => {
+      const localClusterDashboard = new ClusterDashboardPagePo('local');
+
+      localClusterDashboard.goTo();
+
+      chat.open();
+
+      chat.isNotReady();
+      chat.console().isDisabled();
+      chat.context().isDisabled();
+
+      chat.isReady();
+      chat.console().isNotDisabled();
+      chat.context().isNotDisabled();
+      chat.messagesPanel().processingState().should('not.exist');
+    });
+
+    it('It should not become ready when chat is not initialized', () => {
+      const localClusterDashboard = new ClusterDashboardPagePo('local');
+
+      localClusterDashboard.goTo();
+
+      // Mock th WebSocket to never receive the chat-metadata message, so the chat will never become ready
+      // We want to simulate delayed initialization of the chat - this can happen when several agents are defined
+      // so the server takes longer to check all MCP servers and send the chat-metadata containing the agents list.
+      cy.window().then((win) => {
+        const OriginalWebSocket = win.WebSocket;
+
+        cy.stub(win, 'WebSocket').callsFake((url, protocols) => {
+          const ws = new OriginalWebSocket(url, protocols);
+
+          Object.defineProperty(ws, 'onmessage', {
+            set(originalListener) {
+              this._onmessage = function(event: MessageEvent) {
+                // Intercept the chat-metadata message and replace it with a fake one
+                if (event.data.includes('<chat-metadata>')) {
+                  const mockEvent = new MessageEvent('message', { data: '<chat-metadata></chat-metadata>' });
+
+                  return originalListener.call(this, mockEvent);
+                }
+
+                return originalListener.call(this, event);
+              };
+            },
+          });
+
+          return ws;
+        });
+      });
+
+      chat.open();
+
+      chat.messagesPanel().processingState().contains('Preparing chat').should('be.visible');
+      chat.isNotReady();
+      chat.console().isDisabled();
+      chat.context().isDisabled();
+    });
+
+    it('it should show Generating response label and NOT UI tools label', () => {
+      HomePagePo.goTo();
+
+      chat.open();
+
+      const welcomeMessage = chat.getMessage(1);
+
+      welcomeMessage.isCompleted();
+
+      for (let i = 0; i < 2; i++) {
+        chat.sendMessage(`Request ${ i + 1 }`);
+
+        chat.messagesPanel().processingState('Generating response').should('be.visible');
+
+        chat.messagesPanel().processingState('Processing UI tools').should('not.exist');
+
+        const responseMessage = chat.getMessage(3 + (i * 2));
+
+        responseMessage.isCompleted();
+      }
+
+      chat.messagesPanel().processingState().should('not.exist');
+    });
+
+    it('it should show Generating response label AND UI tools label', () => {
+      cy.installUIToolsDefinition();
+
+      HomePagePo.goTo();
+
+      chat.open();
+
+      const welcomeMessage = chat.getMessage(1);
+
+      welcomeMessage.isCompleted();
+
+      for (let i = 0; i < 2; i++) {
+        chat.sendMessage(`Request ${ i + 1 }`);
+
+        chat.messagesPanel().processingState('Generating response').should('be.visible');
+
+        chat.messagesPanel().processingState('Processing UI tools').should('be.visible');
+
+        const responseMessage = chat.getMessage(3 + (i * 2));
+
+        responseMessage.isCompleted();
+      }
+
+      chat.messagesPanel().processingState().should('not.exist');
+
+      cy.uninstallUIToolsDefinition();
     });
 
     it('it should support reconnections on settings changes', () => {
@@ -132,6 +247,9 @@ describe('Chat', () => {
       // Check for the reconnecting phase
       chat.isNotReady();
       chat.processingState('Reconnecting').should('be.visible');
+
+      // Verify that the processing message state is not visible when connection phase is visible
+      chat.messagesPanel().processingState().should('not.exist');
 
       chat.isReady(20000);
       chat.processingState('Reconnecting').should('not.exist');
@@ -187,12 +305,18 @@ describe('Chat', () => {
       chat.isNotReady();
       chat.processingState('Reconnecting').should('be.visible');
 
+      // Verify that the processing message state is not visible when connection phase is visible
+      chat.messagesPanel().processingState().should('not.exist');
+
       chat.close();
       chat.open();
 
       // Reconnection should happen and the chat should be ready after that
       chat.isNotReady();
       chat.processingState('Connecting').should('be.visible');
+
+      // Verify that the processing message state is not visible when connection phase is visible
+      chat.messagesPanel().processingState().should('not.exist');
 
       chat.isReady(20000);
       chat.processingState('Connecting').should('not.exist');
@@ -222,6 +346,9 @@ describe('Chat', () => {
 
       cy.installRancherAIService({ waitForAIServiceReady: false });
 
+      // Verify that the processing message state is not visible when connection phase is visible
+      chat.messagesPanel().processingState().should('not.exist');
+
       // Check for the disconnected phase and error message
       chat.isNotReady();
       chat.processingState('Disconnected').should('be.visible');
@@ -231,6 +358,9 @@ describe('Chat', () => {
       // Check for the reconnecting phase
       chat.isNotReady();
       chat.processingState('Connecting').should('be.visible');
+
+      // Verify that the processing message state is not visible when connection phase is visible
+      chat.messagesPanel().processingState().should('not.exist');
 
       chat.isReady(20000);
       chat.processingState('Connecting').should('not.exist');
@@ -259,6 +389,9 @@ describe('Chat', () => {
       // Check for the reconnecting phase
       chat.isNotReady();
       chat.processingState('Connecting').should('be.visible');
+
+      // Verify that the processing message state is not visible when connection phase is visible
+      chat.messagesPanel().processingState().should('not.exist');
 
       chat.isReady(20000);
       chat.processingState('Connecting').should('not.exist');
@@ -316,6 +449,9 @@ describe('Chat', () => {
 
       chat.processingState('Connecting').should('be.visible');
 
+      // Verify that the processing message state is not visible when connection phase is visible
+      chat.messagesPanel().processingState().should('not.exist');
+
       chat.isReady(20000);
       chat.processingState('Connecting').should('not.exist');
 
@@ -334,6 +470,8 @@ describe('Chat', () => {
     });
 
     after(() => {
+      cy.login();
+      cy.uninstallUIToolsDefinition();
       cy.installRancherAIService();
     });
   });
@@ -502,11 +640,11 @@ describe('Chat', () => {
 
       chat.sendMessage('Create a pod named my-pod in default namespace');
 
-      const processingState = chat.processingState('Awaiting confirmation');
+      const processingState = chat.messagesPanel().processingState('Awaiting confirmation');
 
       // Verify the processing label is visible and not covered by the console panel
       processingState.should('be.visible').then(($phase) => {
-        new ContextPo().self().then(($context) => {
+        chat.context().panel().then(($context) => {
           const phaseRect = $phase[0].getBoundingClientRect();
           const contextRect = $context[0].getBoundingClientRect();
 
@@ -557,7 +695,7 @@ describe('Chat', () => {
       responseMessage.self().should('not.be.visible');
 
       // Verify that the processing state is not visible as we scroll up
-      chat.processingState().should('not.be.visible');
+      chat.messagesPanel().processingState().should('not.be.visible');
 
       // Response is still streaming...
       responseMessage.isCompleted();
@@ -646,7 +784,7 @@ describe('Chat', () => {
         responseMessage.isCompleted();
       }
 
-      chat.processingState().should('not.exist');
+      chat.messagesPanel().processingState().should('not.exist');
 
       chat.messagesPanel().scrollTop();
 
@@ -684,7 +822,7 @@ describe('Chat', () => {
         responseMessage.isCompleted();
       }
 
-      chat.processingState().should('not.exist');
+      chat.messagesPanel().processingState().should('not.exist');
 
       chat.messagesPanel().scrollTop();
 
@@ -745,7 +883,7 @@ describe('Chat', () => {
         responseMessage.isCompleted();
       }
 
-      chat.processingState().should('not.exist');
+      chat.messagesPanel().processingState().should('not.exist');
 
       chat.messagesPanel().scrollTop();
 
@@ -785,7 +923,7 @@ describe('Chat', () => {
         responseMessage.isCompleted();
       }
 
-      chat.processingState().should('not.exist');
+      chat.messagesPanel().processingState().should('not.exist');
 
       chat.messagesPanel().scrollTop();
 
@@ -918,7 +1056,7 @@ describe('Chat', () => {
         responseMessage.isCompleted();
       }
 
-      chat.processingState().should('not.exist');
+      chat.messagesPanel().processingState().should('not.exist');
 
       chat.messagesPanel().scrollTop();
 
@@ -973,7 +1111,7 @@ describe('Chat', () => {
         responseMessage.isCompleted();
       }
 
-      chat.processingState().should('not.exist');
+      chat.messagesPanel().processingState().should('not.exist');
 
       // Verify that the request message is not visible and the last message is visible, meaning that the chat has scrolled to the bottom
       chat.getMessage(2).self().should('not.be.visible');
@@ -995,77 +1133,6 @@ describe('Chat', () => {
       systemErrorMessage.containsText('Rancher AI Agent pod not found. Please ensure the Rancher AI assistant services are correctly installed and you have the necessary permissions to access it.');
 
       cy.installRancherAIService({ waitForAIServiceReady: true });
-    });
-
-    after(() => {
-      cy.login();
-      cy.clearLLMResponses();
-      cy.cleanChatHistory();
-      cy.uninstallUIToolsDefinition();
-    });
-  });
-
-  describe('Processing label', () => {
-    before(() => {
-      cy.login();
-      cy.cleanChatHistory();
-      cy.clearLLMResponses();
-    });
-
-    beforeEach(() => {
-      cy.login();
-    });
-
-    it('it should show Generating response label and NOT UI tools label', () => {
-      HomePagePo.goTo();
-
-      chat.open();
-
-      const welcomeMessage = chat.getMessage(1);
-
-      welcomeMessage.isCompleted();
-
-      for (let i = 0; i < 2; i++) {
-        chat.sendMessage(`Request ${ i + 1 }`);
-
-        chat.processingState('Generating response').should('be.visible');
-
-        chat.processingState('Processing UI tools').should('not.exist');
-
-        const responseMessage = chat.getMessage(3 + (i * 2));
-
-        responseMessage.isCompleted();
-      }
-
-      chat.processingState().should('not.exist');
-    });
-
-    it('it should show Generating response label AND UI tools label', () => {
-      cy.installUIToolsDefinition();
-
-      HomePagePo.goTo();
-
-      chat.open();
-
-      const welcomeMessage = chat.getMessage(1);
-
-      welcomeMessage.isCompleted();
-
-      for (let i = 0; i < 2; i++) {
-        chat.sendMessage(`Request ${ i + 1 }`);
-
-        chat.processingState('Generating response').should('be.visible');
-
-        chat.processingState('Processing UI tools').should('be.visible');
-
-        const responseMessage = chat.getMessage(3 + (i * 2));
-
-        responseMessage.isCompleted();
-      }
-
-      chat.processingState().should('not.exist');
-
-      cy.uninstallUIToolsDefinition();
     });
 
     after(() => {

--- a/cypress/e2e/tests/features/hooks.spec.ts
+++ b/cypress/e2e/tests/features/hooks.spec.ts
@@ -84,6 +84,7 @@ describe('Hooks', () => {
 
       const message = chat.getMessage(2);
 
+      message.scrollIntoView();
       message.containsText('Please analyse the Pod "error-pod" and troubleshoot any problems.');
       message.containsText('See More');
 
@@ -122,6 +123,7 @@ describe('Hooks', () => {
 
       const message = chat.getMessage(2);
 
+      message.scrollIntoView();
       message.containsText('Hey Liz, please analyse the "containers with unready status: [container-0]" message and troubleshoot any problems.');
       message.containsText('See More');
 
@@ -160,6 +162,7 @@ describe('Hooks', () => {
 
       const message = chat.getMessage(1);
 
+      message.scrollIntoView();
       message.containsText('Please analyse the Cluster "local" and troubleshoot any problems.');
       message.containsText('See More');
 
@@ -202,6 +205,7 @@ describe('Hooks', () => {
 
       const message = chat.getMessage(1);
 
+      message.scrollIntoView();
       message.containsText('Please analyse the Cluster "local" and troubleshoot any problems.');
       message.containsText('See More');
 
@@ -233,6 +237,7 @@ describe('Hooks', () => {
 
       const message = chat.getMessage(2);
 
+      message.scrollIntoView();
       message.containsText('Please analyse the Cluster "local" and troubleshoot any problems.');
       message.containsText('See More');
 

--- a/cypress/e2e/tests/features/multi-agent/message.spec.ts
+++ b/cypress/e2e/tests/features/multi-agent/message.spec.ts
@@ -340,7 +340,7 @@ describe('Multi Agent Messages', () => {
     confirmationRequestMessage.isCompleted();
     confirmationRequestMessage.containsText('Are you sure you want to proceed with this action?');
 
-    chat.processingState('Awaiting confirmation').should('be.visible');
+    chat.messagesPanel().processingState('Awaiting confirmation').should('be.visible');
 
     confirmationRequestMessage.confirmButton().click();
 

--- a/cypress/e2e/tests/features/multi-agent/oauth2.spec.ts
+++ b/cypress/e2e/tests/features/multi-agent/oauth2.spec.ts
@@ -1,0 +1,389 @@
+import { McpAuthenticationResponse } from '../../../../../pkg/rancher-ai-ui/types';
+import HomePagePo from '@rancher/cypress/e2e/po/pages/home.po';
+import ChatPo from '@/cypress/e2e/po/chat.po';
+import { harvesterAgentConfig } from '@/cypress/e2e/blueprints/aiAgentConfigs';
+
+const OAUTH2_CHANNEL_NAME = 'oauth_channel';
+const OAUTH2_SUCCESS_MESSAGE = 'oauth_success';
+
+/**
+ * Stubs the OAuth2 popup behavior for testing purposes.
+ *
+ * if result is 'success'
+ *   it simulates a successful OAuth2 authentication
+ *   by sending a message to the BroadcastChannel after a short delay.
+ *
+ * if result is 'failure'
+ *   it simulates a failed OAuth2 authentication (no message sent to the BroadcastChannel)
+ *   and the popup is closed after a short delay.
+ *
+ * if result is 'idle'
+ *   it returns a stubbed popup, on which no action is taken.
+ *
+ * @param result - The result of the OAuth2 authentication ('success', 'failure', or 'idle').
+ */
+function stubOauth2Popup(result: 'success' | 'failure' | 'idle') {
+  cy.window().then((win) => {
+    if (result === 'idle') {
+      cy.stub(win, 'open').as('popupStub');
+
+      return;
+    }
+
+    cy.stub(win, 'open').as('popupStub').callsFake(() => {
+      if (result === 'success') {
+        setTimeout(() => {
+          const channel = new BroadcastChannel(OAUTH2_CHANNEL_NAME);
+
+          channel.postMessage({ type: OAUTH2_SUCCESS_MESSAGE });
+          channel.close();
+        }, 200);
+      }
+
+      const mockPopup = { closed: false };
+
+      setTimeout(() => {
+        mockPopup.closed = true;
+      }, 500);
+
+      return mockPopup;
+    });
+  });
+}
+
+/**
+ * Stubs the WebSocket send method to intercept messages sent by the main UI.
+ * This allows us to verify that the correct messages are sent after OAuth2 authentication.
+ *
+ * IMPORTANT:
+ *   This function should be called before chat opening to ensure that the WebSocket is stubbed
+ *   before the WebSocket connection is established.
+ */
+function stubWebSocketSend() {
+  cy.window().then((win) => {
+    const OriginalWebSocket = win.WebSocket;
+
+    cy.stub(win, 'WebSocket').callsFake((url, protocols) => {
+      const wsInstance = new OriginalWebSocket(url, protocols);
+
+      cy.spy(wsInstance, 'send').as('wsSend');
+
+      return wsInstance;
+    });
+  });
+}
+
+describe('Multi Agent OAuth2 Authentication', () => {
+  const chat = new ChatPo();
+
+  const defaultAgent = {
+    name:        'rancher',
+    displayName: 'Rancher',
+    description: 'Rancher built-in agent',
+  };
+
+  const customAgent = {
+    name:        'harvester',
+    displayName: 'Harvester',
+    description: 'Harvester custom agent',
+  };
+
+  const popupUrl = 'https://suse.com';
+  const oauth2Response = `<authentication>{"type": "oauth2", "url": "${ popupUrl }", "agent": "${ defaultAgent.name }"}</authentication>`;
+
+  before(() => {
+    cy.login();
+    // Create a custom agent config to enable multi-agent switching
+    cy.createAgentConfig(harvesterAgentConfig);
+    cy.cleanChatHistory();
+  });
+
+  beforeEach(() => {
+    cy.login();
+    cy.clearLLMResponses();
+
+    HomePagePo.goTo();
+
+    stubWebSocketSend();
+
+    chat.open();
+
+    const welcomeMessage = chat.getMessage(1);
+
+    welcomeMessage.isCompleted();
+  });
+
+  it('It should confirm authentication request with success when agent selection is manual', () => {
+    stubOauth2Popup('success');
+
+    const selectAgent = chat.console().selectAgent();
+
+    selectAgent.self().contains('Adaptive Agent(s) Selection');
+
+    selectAgent.open();
+
+    const item = selectAgent.agentItem(customAgent.name);
+
+    item.select();
+
+    selectAgent.self().contains(customAgent.displayName);
+
+    cy.enqueueLLMResponse({ text: oauth2Response });
+
+    chat.sendMessage('Request message.');
+
+    const authRequestMessage = chat.getMessage(4);
+
+    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
+    authRequestMessage.containsText('The tool you have selected requires authentication');
+
+    authRequestMessage.confirmButton().click();
+
+    authRequestMessage.isConfirmed();
+
+    // Verify that the popup was opened
+    cy.get('@popupStub').should('be.calledOnce');
+    cy.get('@popupStub').should('be.calledWithMatch', popupUrl);
+
+    // Verify that the WebSocket send method was called with the expected message after receving the OAuth2 success message from the popup
+    cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Continue);
+  });
+
+  it('It should confirm authentication request with failure when agent selection is manual', () => {
+    stubOauth2Popup('failure');
+
+    const selectAgent = chat.console().selectAgent();
+
+    selectAgent.self().contains('Adaptive Agent(s) Selection');
+
+    selectAgent.open();
+
+    const item = selectAgent.agentItem(customAgent.name);
+
+    item.select();
+
+    selectAgent.self().contains(customAgent.displayName);
+
+    cy.enqueueLLMResponse({ text: oauth2Response });
+
+    chat.sendMessage('Request message.');
+
+    const authRequestMessage = chat.getMessage(4);
+
+    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
+    authRequestMessage.containsText('The tool you have selected requires authentication');
+
+    authRequestMessage.confirmButton().click();
+
+    authRequestMessage.isConfirmed();
+
+    // Verify that the popup was opened
+    cy.get('@popupStub').should('be.calledOnce');
+    cy.get('@popupStub').should('be.calledWithMatch', popupUrl);
+
+    // Verify that the WebSocket send method was called with the expected message after the popup is closed without sending the OAuth2 success message
+    cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Cancel);
+  });
+
+  it('It should cancel authentication request when agent selection is manual', () => {
+    stubOauth2Popup('idle');
+
+    const selectAgent = chat.console().selectAgent();
+
+    selectAgent.self().contains('Adaptive Agent(s) Selection');
+
+    selectAgent.open();
+
+    const item = selectAgent.agentItem(customAgent.name);
+
+    item.select();
+
+    selectAgent.self().contains(customAgent.displayName);
+
+    cy.enqueueLLMResponse({ text: oauth2Response });
+
+    chat.sendMessage('Request message.');
+
+    const authRequestMessage = chat.getMessage(4);
+
+    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
+    authRequestMessage.containsText('The tool you have selected requires authentication');
+
+    authRequestMessage.cancelButton().click();
+
+    authRequestMessage.isCanceled();
+
+    // Verify that the popup was not opened
+    cy.get('@popupStub').should('not.be.called');
+
+    // Verify that the WebSocket send method was called with the expected message after cancel is clicked
+    cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Cancel);
+  });
+
+  it('It should confirm authentication request with success when agent selection is adaptive', () => {
+    stubOauth2Popup('success');
+
+    const selectAgent = chat.console().selectAgent();
+
+    selectAgent.self().contains('Adaptive Agent(s) Selection');
+
+    cy.enqueueLLMResponse({
+      agentResponses: [{ agent: defaultAgent.name }],
+      text:           oauth2Response
+    });
+
+    chat.sendMessage('Request message.');
+
+    const authRequestMessage = chat.getMessage(4);
+
+    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
+    authRequestMessage.containsText('The tool you have selected requires authentication');
+
+    authRequestMessage.confirmButton().click();
+
+    authRequestMessage.isConfirmed();
+
+    // Verify that the popup was opened
+    cy.get('@popupStub').should('be.calledOnce');
+    cy.get('@popupStub').should('be.calledWithMatch', popupUrl);
+
+    // Verify that the WebSocket send method was called with the expected message after receving the OAuth2 success message from the popup
+    cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Continue);
+  });
+
+  it('It should confirm authentication request with failure when agent selection is adaptive', () => {
+    stubOauth2Popup('failure');
+
+    const selectAgent = chat.console().selectAgent();
+
+    selectAgent.self().contains('Adaptive Agent(s) Selection');
+
+    cy.enqueueLLMResponse({
+      agentResponses: [{ agent: defaultAgent.name }],
+      text:           oauth2Response
+    });
+
+    chat.sendMessage('Request message.');
+
+    const authRequestMessage = chat.getMessage(4);
+
+    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
+    authRequestMessage.containsText('The tool you have selected requires authentication');
+
+    authRequestMessage.confirmButton().click();
+
+    authRequestMessage.isConfirmed();
+
+    // Verify that the popup was opened
+    cy.get('@popupStub').should('be.calledOnce');
+    cy.get('@popupStub').should('be.calledWithMatch', popupUrl);
+
+    // Verify that the WebSocket send method was called with the expected message after the popup is closed without sending the OAuth2 success message
+    cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Cancel);
+  });
+
+  it('It should cancel authentication request when agent selection is adaptive', () => {
+    stubOauth2Popup('idle');
+
+    const selectAgent = chat.console().selectAgent();
+
+    selectAgent.self().contains('Adaptive Agent(s) Selection');
+
+    cy.enqueueLLMResponse({ text: oauth2Response });
+
+    chat.sendMessage('Request message.');
+
+    const authRequestMessage = chat.getMessage(4);
+
+    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
+    authRequestMessage.containsText('The tool you have selected requires authentication');
+
+    authRequestMessage.cancelButton().click();
+
+    authRequestMessage.isCanceled();
+
+    // Verify that the popup was not opened
+    cy.get('@popupStub').should('not.be.called');
+
+    // Verify that the WebSocket send method was called with the expected message after cancel is clicked
+    cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Cancel);
+  });
+
+  it('It should abort pending authentication requests when closing the chat panel', () => {
+    stubOauth2Popup('success');
+
+    const selectAgent = chat.console().selectAgent();
+
+    selectAgent.open();
+
+    const item = selectAgent.agentItem(customAgent.name);
+
+    item.select();
+
+    selectAgent.self().contains(customAgent.displayName);
+
+    cy.enqueueLLMResponse({ text: oauth2Response });
+
+    chat.sendMessage('Request message.');
+
+    const authRequestMessage = chat.getMessage(4);
+
+    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
+    authRequestMessage.containsText('The tool you have selected requires authentication');
+
+    authRequestMessage.confirmButton().click();
+
+    authRequestMessage.isConfirmed();
+
+    chat.close();
+
+    // Verify that the popup was opened
+    cy.get('@popupStub').should('be.calledOnce');
+    cy.get('@popupStub').should('be.calledWithMatch', popupUrl);
+
+    // Verify that the WebSocket send method was called with the expected message after the popup is closed without sending the OAuth2 success message
+    cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Cancel);
+  });
+
+  it('It should abort pending authentication requests when connection is lost', () => {
+    stubOauth2Popup('success');
+
+    const selectAgent = chat.console().selectAgent();
+
+    selectAgent.open();
+
+    const item = selectAgent.agentItem(customAgent.name);
+
+    item.select();
+
+    selectAgent.self().contains(customAgent.displayName);
+
+    cy.enqueueLLMResponse({ text: oauth2Response });
+
+    chat.sendMessage('Request message.');
+
+    const authRequestMessage = chat.getMessage(4);
+
+    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
+    authRequestMessage.containsText('The tool you have selected requires authentication');
+
+    authRequestMessage.confirmButton().click();
+
+    authRequestMessage.isConfirmed();
+
+    // Simulate connection loss re-installing the Rancher AI service
+    cy.installRancherAIService();
+
+    // Verify that the popup was opened
+    cy.get('@popupStub').should('be.calledOnce');
+    cy.get('@popupStub').should('be.calledWithMatch', popupUrl);
+
+    cy.get('@wsSend').should('not.be.called');
+  });
+
+  after(() => {
+    cy.deleteAgentConfig(harvesterAgentConfig);
+    cy.cleanChatHistory();
+    cy.clearLLMResponses();
+  });
+});

--- a/cypress/e2e/tests/features/multi-agent/oauth2.spec.ts
+++ b/cypress/e2e/tests/features/multi-agent/oauth2.spec.ts
@@ -9,6 +9,8 @@ const OAUTH2_SUCCESS_MESSAGE = 'oauth_success';
 /**
  * Stubs the OAuth2 popup behavior for testing purposes.
  *
+ * Also stores a spy on the popup's close method on the window for later access.
+ *
  * if result is 'success'
  *   it simulates a successful OAuth2 authentication
  *   by sending a message to the BroadcastChannel after a short delay.
@@ -40,7 +42,17 @@ function stubOauth2Popup(result: 'success' | 'failure' | 'idle') {
         }, 200);
       }
 
-      const mockPopup = { closed: false };
+      let closeCalled = false;
+
+      const mockPopup = {
+        closed: false,
+        close:  () => {
+          closeCalled = true;
+        }
+      };
+
+      // Store close tracking on window
+      (win as any).testPopupCloseCalled = () => closeCalled;
 
       setTimeout(() => {
         mockPopup.closed = true;
@@ -55,6 +67,8 @@ function stubOauth2Popup(result: 'success' | 'failure' | 'idle') {
  * Stubs the WebSocket send method to intercept messages sent by the main UI.
  * This allows us to verify that the correct messages are sent after OAuth2 authentication.
  *
+ * Also stores the WebSocket instance and its send spy on the window for later access.
+ *
  * IMPORTANT:
  *   This function should be called before chat opening to ensure that the WebSocket is stubbed
  *   before the WebSocket connection is established.
@@ -66,7 +80,12 @@ function stubWebSocketSend() {
     cy.stub(win, 'WebSocket').callsFake((url, protocols) => {
       const wsInstance = new OriginalWebSocket(url, protocols);
 
-      cy.spy(wsInstance, 'send').as('wsSend');
+      const wsSpy = cy.spy(wsInstance, 'send');
+
+      (win as any).testWebSocket = wsInstance;
+      (win as any).testWsSpy = wsSpy;
+
+      wsSpy.as('wsSend');
 
       return wsInstance;
     });
@@ -309,42 +328,6 @@ describe('Multi Agent OAuth2 Authentication', () => {
     cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Cancel);
   });
 
-  it('It should abort pending authentication requests when closing the chat panel', () => {
-    stubOauth2Popup('success');
-
-    const selectAgent = chat.console().selectAgent();
-
-    selectAgent.open();
-
-    const item = selectAgent.agentItem(customAgent.name);
-
-    item.select();
-
-    selectAgent.self().contains(customAgent.displayName);
-
-    cy.enqueueLLMResponse({ text: oauth2Response });
-
-    chat.sendMessage('Request message.');
-
-    const authRequestMessage = chat.getMessage(4);
-
-    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
-    authRequestMessage.containsText('The tool you have selected requires authentication');
-
-    authRequestMessage.confirmButton().click();
-
-    authRequestMessage.isConfirmed();
-
-    chat.close();
-
-    // Verify that the popup was opened
-    cy.get('@popupStub').should('be.calledOnce');
-    cy.get('@popupStub').should('be.calledWithMatch', popupUrl);
-
-    // Verify that the WebSocket send method was called with the expected message after the popup is closed without sending the OAuth2 success message
-    cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Cancel);
-  });
-
   it('It should abort pending authentication requests when connection is lost', () => {
     stubOauth2Popup('success');
 
@@ -367,18 +350,85 @@ describe('Multi Agent OAuth2 Authentication', () => {
     authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
     authRequestMessage.containsText('The tool you have selected requires authentication');
 
+    // Reset spy before clicking confirm
+    cy.window().then((win) => {
+      (win as any).testWsSpy.resetHistory();
+    });
+
     authRequestMessage.confirmButton().click();
 
     authRequestMessage.isConfirmed();
 
-    // Simulate connection loss re-installing the Rancher AI service
-    cy.installRancherAIService();
+    // Simulate connection loss by closing the WebSocket
+    cy.window().then((win) => {
+      (win as any).testWebSocket.close();
+    });
+
+    // Wait for the connection loss to be processed (> 200ms delay in the stubbed popup)
+    cy.wait(300);
 
     // Verify that the popup was opened
     cy.get('@popupStub').should('be.calledOnce');
     cy.get('@popupStub').should('be.calledWithMatch', popupUrl);
 
+    // Verify popup has been closed
+    cy.window().then((win) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect((win as any).testPopupCloseCalled()).to.be.true;
+    });
+
+    // Verify that the WebSocket send method was not called after connection loss
     cy.get('@wsSend').should('not.be.called');
+  });
+
+  it('It should abort pending authentication requests when closing the chat panel', () => {
+    stubOauth2Popup('failure');
+
+    const selectAgent = chat.console().selectAgent();
+
+    selectAgent.open();
+
+    const item = selectAgent.agentItem(customAgent.name);
+
+    item.select();
+
+    selectAgent.self().contains(customAgent.displayName);
+
+    cy.enqueueLLMResponse({ text: oauth2Response });
+
+    chat.sendMessage('Request message.');
+
+    const authRequestMessage = chat.getMessage(4);
+
+    authRequestMessage.agentSelectionLabel().contains(`Agent: ${ defaultAgent.displayName }`);
+    authRequestMessage.containsText('The tool you have selected requires authentication');
+
+    // Reset spy before clicking confirm
+    cy.window().then((win) => {
+      (win as any).testWsSpy.resetHistory();
+    });
+
+    authRequestMessage.confirmButton().click();
+
+    authRequestMessage.isConfirmed();
+
+    chat.close();
+
+    // Wait for the normal success message (> 200ms delay in the stubbed popup) to proof that the popup was closed due to the chat panel being closed and not due to the normal success message.
+    cy.wait(300);
+
+    // Verify that the popup was opened
+    cy.get('@popupStub').should('be.calledOnce');
+    cy.get('@popupStub').should('be.calledWithMatch', popupUrl);
+
+    // Verify popup has been closed
+    cy.window().then((win) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect((win as any).testPopupCloseCalled()).to.be.true;
+    });
+
+    // Verify that the WebSocket send method was called with Cancel after closing the chat
+    cy.get('@wsSend').should('be.calledWithMatch', McpAuthenticationResponse.Cancel);
   });
 
   after(() => {

--- a/cypress/e2e/tests/features/settings.spec.ts
+++ b/cypress/e2e/tests/features/settings.spec.ts
@@ -5,6 +5,7 @@ import ApplySettingsPromptPo from '@/cypress/e2e/po/dialog/apply-settings.po';
 
 describe('AI Assistant Configuration', () => {
   const settingsPage = new SettingsPagePo();
+  const apiPath = `/api/v1/namespaces/cattle-ai-agent-system/services/http:rancher-ai-agent:80/proxy/v1/api`;
 
   const initValues = {
     llm:          'ollama',
@@ -90,7 +91,7 @@ describe('AI Assistant Configuration', () => {
       settingsPage.waitForPage();
     });
 
-    it('It should correctly handle the AI Agent configs', () => {
+    it('It should correctly show the AI Agents', () => {
       const aiAgentConfigs = settingsPage.settings().aiAgentConfigs();
 
       aiAgentConfigs.checkExists();
@@ -104,6 +105,10 @@ describe('AI Assistant Configuration', () => {
       // Check that Rancher Agent is enabled and locked (it is a built-in agent)
       aiAgentConfigs.tabs().assertTabIsActive(`[data-testid="${ initValues.rancherAgent }"]`);
       aiAgentConfigs.self().should('contain', 'This AI agent is locked');
+    });
+
+    it('It should correctly add new AI Agent', () => {
+      const aiAgentConfigs = settingsPage.settings().aiAgentConfigs();
 
       // Add a custom AI Agent
       aiAgentConfigs.tabs().addTab();
@@ -137,10 +142,14 @@ describe('AI Assistant Configuration', () => {
       settingsPage.waitForPage();
 
       aiAgentConfigs.tabs().assertTabIsActive(`[data-testid^="${ updatedValues.customAgentPrefix }"]`);
-      aiAgentConfigs.mcpUrlInput().value().should('eq', 'http://my-mcp-url:8080');
+      aiAgentConfigs.mcpUrlInput().self().should('have.value', 'http://my-mcp-url:8080');
 
       // Check that the new agent tab is showing error status due to invalid MCP URL
       aiAgentConfigs.tabs().assertTabHasLabelIcon(`[data-testid^="${ updatedValues.customAgentPrefix }"]`, 'icon-error');
+    });
+
+    it('It should correctly remove an existing AI Agent', () => {
+      const aiAgentConfigs = settingsPage.settings().aiAgentConfigs();
 
       // Remove the custom AI Agent
       aiAgentConfigs.tabs().removeTab();
@@ -160,5 +169,113 @@ describe('AI Assistant Configuration', () => {
       aiAgentConfigs.tabs().getTabByPrefix(updatedValues.customAgentPrefix).checkNotExists();
       aiAgentConfigs.tabs().assertTabIsActive(`[data-testid="${ initValues.rancherAgent }"]`);
     });
+
+    it('It should correctly setup OAuth2 authentication', () => {
+      const aiAgentConfigs = settingsPage.settings().aiAgentConfigs();
+
+      // Add a custom AI Agent
+      aiAgentConfigs.tabs().addTab();
+
+      aiAgentConfigs.tabs().getTabByPrefix(updatedValues.customAgentPrefix).checkExists();
+
+      aiAgentConfigs.tabs().assertTabIsActive(`[data-testid^="${ updatedValues.customAgentPrefix }"]`);
+
+      settingsPage.settings().saveButton().should('be.disabled');
+
+      aiAgentConfigs.mcpUrlInput().set('http://my-mcp-url:8080');
+
+      // Fill the required fields for OAuth2 authentication
+      aiAgentConfigs.authenticationTypeSelector().toggle();
+      aiAgentConfigs.authenticationTypeSelector().clickOptionWithLabel('OAuth2 authentication');
+
+      settingsPage.settings().saveButton().should('be.disabled');
+
+      cy.intercept('GET', `${ apiPath }/oauth2/metadata?*`, {
+        statusCode: 200,
+        body:       {
+          metadataEndpoint: 'http://my-metadata-endpoint:8080',
+          scopesSupported:  ['scope1', 'scope2']
+        }
+      }).as('metadataDiscovery');
+
+      aiAgentConfigs.metadataDiscoveryButton().click();
+
+      cy.wait('@metadataDiscovery');
+
+      // Verify that the metadata discovery populated the metadata endpoint and scopes
+      aiAgentConfigs.self().should('contain.text', 'The metadata endpoint was successfully retrieved and filled it automatically.');
+      aiAgentConfigs.metadataEndpointInput().self().should('have.value', 'http://my-metadata-endpoint:8080');
+
+      // Save button should still be disabled since the client registration is not done yet
+      settingsPage.settings().saveButton().should('be.disabled');
+
+      aiAgentConfigs.scopesSelector().toggle();
+      aiAgentConfigs.scopesSelector().clickOptionWithLabel('scope1');
+
+      cy.intercept('POST', `${ apiPath }/oauth2/dynamic-registration`, {
+        statusCode: 200,
+        body:       {
+          clientId:     'my-client-id',
+          clientSecret: 'my-client-secret',
+        }
+      }).as('clientInfoDiscovery');
+
+      aiAgentConfigs.clientInfoDiscoveryButton().click();
+
+      // Verify that the client registration discovery populated the client ID and secret
+      aiAgentConfigs.self().should('contain.text', 'The client registration and the scope details were successfully retrieved and filled it automatically.');
+      aiAgentConfigs.clientIdInput().self().should('have.value', 'my-client-id');
+      aiAgentConfigs.clientSecretInput().self().should('have.value', 'my-client-secret');
+
+      // Save button should still be disabled since the description and guidelines are not filled yet
+      settingsPage.settings().saveButton().should('be.disabled');
+
+      cy.wait('@clientInfoDiscovery');
+
+      aiAgentConfigs.descriptionInput().type('Custom agent description');
+      aiAgentConfigs.guidelinesInput().type('Custom agent guidelines');
+
+      // All required fields are filled
+      settingsPage.settings().saveButton().should('be.enabled');
+
+      settingsPage.settings().saveButton().click();
+
+      new ApplySettingsPromptPo().confirm();
+
+      settingsPage.settings().saveButton().should('contain.text', 'Saved');
+
+      cy.intercept('GET', `${ apiPath }/oauth2/metadata?*`, {
+        statusCode: 200,
+        body:       {
+          metadataEndpoint: 'http://my-metadata-endpoint:8080',
+          scopesSupported:  ['scope1', 'scope2']
+        }
+      }).as('metadataDiscovery');
+
+      // Revisit the page to check if the settings were saved correctly
+      settingsPage.goTo();
+      settingsPage.waitForPage();
+
+      aiAgentConfigs.tabs().assertTabIsActive(`[data-testid^="${ updatedValues.customAgentPrefix }"]`);
+      aiAgentConfigs.mcpUrlInput().self().should('have.value', 'http://my-mcp-url:8080');
+      aiAgentConfigs.authenticationTypeSelector().self().should('contain.text', 'OAuth2 authentication');
+
+      // Wait for the metadata init fetch to populate the scopes
+      cy.wait('@metadataDiscovery');
+
+      aiAgentConfigs.authenticationTypeSelector().self().scrollIntoView();
+
+      aiAgentConfigs.authenticationTypeSelector().self().should('contain.text', 'OAuth2 authentication');
+      aiAgentConfigs.self().should('contain.text', 'Try to automatically discover the metadata endpoint below based on the MCP endpoint URL.');
+      aiAgentConfigs.self().should('contain.text', 'Try to automatically discover the client registration and the scope details below based on the Metadata endpoint URL.');
+      aiAgentConfigs.metadataEndpointInput().self().should('have.value', 'http://my-metadata-endpoint:8080');
+      aiAgentConfigs.self().should('contain.text', 'scope1');
+      aiAgentConfigs.clientIdInput().self().should('have.value', 'my-client-id');
+      aiAgentConfigs.clientSecretInput().self().should('have.value', 'my-client-secret');
+    });
+  });
+
+  after(() => {
+    cy.installRancherAIService();
   });
 });

--- a/cypress/e2e/tests/features/settings.spec.ts
+++ b/cypress/e2e/tests/features/settings.spec.ts
@@ -203,7 +203,7 @@ describe('AI Assistant Configuration', () => {
       cy.wait('@metadataDiscovery');
 
       // Verify that the metadata discovery populated the metadata endpoint and scopes
-      aiAgentConfigs.self().should('contain.text', 'The metadata endpoint was successfully retrieved and filled it automatically.');
+      aiAgentConfigs.self().should('contain.text', 'The metadata endpoint and scope details were successfully retrieved and filled it automatically.');
       aiAgentConfigs.metadataEndpointInput().self().should('have.value', 'http://my-metadata-endpoint:8080');
 
       // Save button should still be disabled since the client registration is not done yet
@@ -223,7 +223,7 @@ describe('AI Assistant Configuration', () => {
       aiAgentConfigs.clientInfoDiscoveryButton().click();
 
       // Verify that the client registration discovery populated the client ID and secret
-      aiAgentConfigs.self().should('contain.text', 'The client registration and the scope details were successfully retrieved and filled it automatically.');
+      aiAgentConfigs.self().should('contain.text', 'The client registration details were successfully retrieved and filled it automatically.');
       aiAgentConfigs.clientIdInput().self().should('have.value', 'my-client-id');
       aiAgentConfigs.clientSecretInput().self().should('have.value', 'my-client-secret');
 
@@ -266,8 +266,8 @@ describe('AI Assistant Configuration', () => {
       aiAgentConfigs.authenticationTypeSelector().self().scrollIntoView();
 
       aiAgentConfigs.authenticationTypeSelector().self().should('contain.text', 'OAuth2 authentication');
-      aiAgentConfigs.self().should('contain.text', 'Try to automatically discover the metadata endpoint below based on the MCP endpoint URL.');
-      aiAgentConfigs.self().should('contain.text', 'Try to automatically discover the client registration and the scope details below based on the Metadata endpoint URL.');
+      aiAgentConfigs.self().should('contain.text', 'Try to automatically discover the metadata endpoint and scope details below based on the MCP endpoint URL.');
+      aiAgentConfigs.self().should('contain.text', 'Try to automatically discover the client registration details below based on the metadata endpoint URL.');
       aiAgentConfigs.metadataEndpointInput().self().should('have.value', 'http://my-metadata-endpoint:8080');
       aiAgentConfigs.self().should('contain.text', 'scope1');
       aiAgentConfigs.clientIdInput().self().should('have.value', 'my-client-id');

--- a/pkg/rancher-ai-ui/components/DiscoveryBanner/DiscoveryBanner.vue
+++ b/pkg/rancher-ai-ui/components/DiscoveryBanner/DiscoveryBanner.vue
@@ -8,6 +8,15 @@ interface DiscoveryStatus {
   message?: string;
 }
 
+type BannerAction = 'confirm' | 'cancel';
+
+interface BannerProps {
+  color: string;
+  key: string;
+  message: string;
+  action: BannerAction;
+}
+
 const props = defineProps({
   status: {
     type:    Object as () => DiscoveryStatus,
@@ -21,7 +30,7 @@ const props = defineProps({
 
 const emit = defineEmits(['confirm', 'cancel']);
 
-const banner = computed(() => {
+const banner = computed<BannerProps>(() => {
   const status = props.status;
 
   const color = status?.result || 'info';
@@ -36,6 +45,10 @@ const banner = computed(() => {
     action,
   };
 });
+
+function emitAction(value: BannerAction) {
+  emit(value);
+}
 </script>
 
 <template>
@@ -57,7 +70,7 @@ const banner = computed(() => {
           v-clean-html="content"
           class="clickable-label"
           :data-testid="`rancher-ai-ui-discovery-banner-button-${props.translationKey}`"
-          @click="emit(banner.action as any)"
+          @click="emitAction(banner.action)"
         />
       </template>
     </RichTranslation>

--- a/pkg/rancher-ai-ui/components/DiscoveryBanner/DiscoveryBanner.vue
+++ b/pkg/rancher-ai-ui/components/DiscoveryBanner/DiscoveryBanner.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import Banner from '@components/Banner/Banner.vue';
+import RichTranslation from '@shell/components/RichTranslation.vue';
+
+interface DiscoveryStatus {
+  result?: 'success' | 'warning' | 'info' | null;
+  message?: string;
+}
+
+const props = defineProps({
+  status: {
+    type:    Object as () => DiscoveryStatus,
+    default: () => ({} as DiscoveryStatus),
+  },
+  translationKey: {
+    type:    String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['confirm', 'cancel']);
+
+const banner = computed(() => {
+  const status = props.status;
+
+  const color = status?.result || 'info';
+  const key = status?.result === undefined ? 'info' : status?.result || 'inProgress';
+  const message = status?.message || '';
+  const action = status?.result === null ? 'cancel' : 'confirm';
+
+  return {
+    color,
+    key,
+    message,
+    action,
+  };
+});
+</script>
+
+<template>
+  <Banner
+    class="m-0"
+    :color="banner.color"
+  >
+    <RichTranslation
+      :k="`${props.translationKey}.${banner.key}`"
+    >
+      <template #message>
+        <span
+          v-if="banner.message"
+          v-clean-html="t(`${props.translationKey}.message`, { message: banner.message }, true)"
+        />
+      </template>
+      <template #action="{ content }">
+        <span
+          v-clean-html="content"
+          class="clickable-label"
+          :data-testid="`rancher-ai-ui-discovery-banner-button-${props.translationKey}`"
+          @click="emit(banner.action as any)"
+        />
+      </template>
+    </RichTranslation>
+  </Banner>
+</template>
+
+<style scoped lang="scss">
+.clickable-label {
+  text-decoration: underline;
+  cursor: pointer;
+}
+</style>

--- a/pkg/rancher-ai-ui/components/Processing.vue
+++ b/pkg/rancher-ai-ui/components/Processing.vue
@@ -36,6 +36,10 @@ const props = defineProps({
     type:    Boolean,
     default: true,
   },
+  dataTestPrefix: {
+    type:    String,
+    default: '',
+  }
 });
 
 const dots = computed(() => {
@@ -85,7 +89,7 @@ onBeforeUnmount(() => {
   <div
     v-if="label"
     class="processing-message"
-    :data-testid="`rancher-ai-ui-processing-state-${ label.toLowerCase().replace(/\s/g, '-') }`"
+    :data-testid="`rancher-ai-ui-processing-${ props.dataTestPrefix }-state-${ label.toLowerCase().replace(/\s/g, '-') }`"
   >
     <span>
       {{ label }}

--- a/pkg/rancher-ai-ui/components/message/template/McpAuthenticationRequest.vue
+++ b/pkg/rancher-ai-ui/components/message/template/McpAuthenticationRequest.vue
@@ -5,6 +5,16 @@ import { ConfirmationStatus, Message } from '../../../types';
 import { formatMessageContent } from '../../../utils/format';
 import SystemAvatar from '../avatar/SystemAvatar.vue';
 
+interface Agent {
+  displayName: string;
+  description: string;
+}
+
+interface Content {
+  message?: string;
+  agent?: Agent;
+}
+
 const props = defineProps({
   message: {
     type:    Object as PropType<Message>,
@@ -17,6 +27,8 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['update:message']);
+
+const content = computed<Content | undefined>(() => props.message.templateContent?.content);
 
 const actions = computed(() => {
   const all = props.message?.actions || [];
@@ -46,25 +58,25 @@ function doAction(type: 'confirm' | 'cancel') {
   >
     <SystemAvatar class="chat-msg-avatar" />
     <div
-      v-if="props.message?.templateContent?.content?.message"
+      v-if="content?.message"
       class="chat-system-mcp-request-request-msg-bubble"
     >
       <div class="chat-system-mcp-request-request-msg-text">
         <div
-          v-if="props.message?.templateContent?.content?.agent"
+          v-if="content?.agent"
           data-testid="rancher-ai-ui-chat-message-selected-agent-label"
           class="chat-system-mcp-request-request-msg-agent"
         >
           <span
-            v-clean-tooltip="props.message.templateContent.content.agent.description"
+            v-clean-tooltip="content.agent.description"
             class="chat-system-mcp-request-request-msg-agent-label"
           >
-            {{ t('ai.agents.selectedAgent.label', { agent: props.message.templateContent.content.agent.displayName }) }}
+            {{ t('ai.agents.selectedAgent.label', { agent: content.agent.displayName }) }}
           </span>
         </div>
 
         <span
-          v-clean-html="formatMessageContent(props.message.templateContent.content.message || '')"
+          v-clean-html="formatMessageContent(content.message || '')"
         />
       </div>
 
@@ -182,8 +194,10 @@ function doAction(type: 'confirm' | 'cancel') {
   }
 }
 
+@import '@shell/assets/styles/base/_color-classic.scss';
+
 .theme-dark .chat-system-mcp-request-request-msg-text :deep(code) {
-  color: #C0EFDE;
+  color: $green-40;
 }
 
 .chat-system-mcp-request-request-actions {

--- a/pkg/rancher-ai-ui/components/message/template/McpAuthenticationRequest.vue
+++ b/pkg/rancher-ai-ui/components/message/template/McpAuthenticationRequest.vue
@@ -117,7 +117,7 @@ function doAction(type: 'confirm' | 'cancel') {
 <style lang='scss' scoped>
 .chat-system-mcp-request-request-message {
   display: flex;
-  gap: 8px;
+  gap: var(--gap);
 }
 
 .chat-system-mcp-request-request-msg-bubble {
@@ -189,12 +189,12 @@ function doAction(type: 'confirm' | 'cancel') {
 .chat-system-mcp-request-request-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--gap);
   margin-top: 16px;
 
   &-buttons {
     display: flex;
-    gap: 8px;
+    gap: var(--gap);
   }
 }
 

--- a/pkg/rancher-ai-ui/components/message/template/McpAuthenticationRequest.vue
+++ b/pkg/rancher-ai-ui/components/message/template/McpAuthenticationRequest.vue
@@ -1,0 +1,221 @@
+<script setup lang="ts">
+import { computed, type PropType } from 'vue';
+import RcButton from '@components/RcButton/RcButton.vue';
+import { ConfirmationStatus, Message } from '../../../types';
+import { formatMessageContent } from '../../../utils/format';
+import SystemAvatar from '../avatar/SystemAvatar.vue';
+
+const props = defineProps({
+  message: {
+    type:    Object as PropType<Message>,
+    default: () => ({} as Message),
+  },
+  disabled: {
+    type:    Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:message']);
+
+const actions = computed(() => {
+  const all = props.message?.actions || [];
+
+  return {
+    confirm: all[0],
+    cancel:  all[1],
+  };
+});
+
+function doAction(type: 'confirm' | 'cancel') {
+  if (actions.value[type]?.action) {
+    const confirmation = actions.value[type].action();
+
+    emit('update:message', {
+      ...props.message,
+      confirmation
+    });
+  }
+}
+</script>
+
+<template>
+  <div
+    class="chat-system-mcp-request-request-message"
+    :class="{ 'disabled-panel': props.disabled }"
+  >
+    <SystemAvatar class="chat-msg-avatar" />
+    <div
+      v-if="props.message?.templateContent?.content?.message"
+      class="chat-system-mcp-request-request-msg-bubble"
+    >
+      <div class="chat-system-mcp-request-request-msg-text">
+        <div
+          v-if="props.message?.templateContent?.content?.agent"
+          data-testid="rancher-ai-ui-chat-message-selected-agent-label"
+          class="chat-system-mcp-request-request-msg-agent"
+        >
+          <span
+            v-clean-tooltip="props.message.templateContent.content.agent.description"
+            class="chat-system-mcp-request-request-msg-agent-label"
+          >
+            {{ t('ai.agents.selectedAgent.label', { agent: props.message.templateContent.content.agent.displayName }) }}
+          </span>
+        </div>
+
+        <span
+          v-clean-html="formatMessageContent(props.message.templateContent.content.message || '')"
+        />
+      </div>
+
+      <div class="chat-system-mcp-request-request-actions">
+        <div
+          v-if="props.message.confirmation"
+          :data-testid="`rancher-ai-ui-chat-message-confirmation-${ props.message.confirmation?.status === ConfirmationStatus.Confirmed ? 'confirmed' : 'canceled'}`"
+          :class="['chat-system-mcp-request-request-actions-result', `status-${props.message.confirmation.status}` ]"
+        >
+          <i
+            :class="[ 'icon', props.message.confirmation.icon ]"
+          />
+          <span
+            v-clean-html="formatMessageContent(props.message.confirmation.label || '')"
+            class="chat-system-mcp-request-request-msg-text"
+          />
+        </div>
+        <div
+          v-else
+          class="chat-system-mcp-request-request-actions-buttons"
+        >
+          <RcButton
+            v-if="actions.cancel?.action"
+            small
+            tertiary
+            data-testid="rancher-ai-ui-chat-message-confirmation-cancel-button"
+            @click="doAction('cancel')"
+          >
+            <span class="rc-button-label">
+              {{ actions.cancel?.label }}
+            </span>
+          </RcButton>
+          <RcButton
+            v-if="actions.confirm?.action"
+            small
+            tertiary
+            data-testid="rancher-ai-ui-chat-message-confirmation-confirm-button"
+            @click="doAction('confirm')"
+          >
+            <span class="rc-button-label">
+              {{ actions.confirm?.label }}
+            </span>
+          </RcButton>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang='scss' scoped>
+.chat-system-mcp-request-request-message {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-system-mcp-request-request-msg-bubble {
+  position: relative;
+  background: var(--body-bg);
+  color: var(--body-text);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 2px 8px 0 rgba(0,0,0,0.04);
+  padding: 12px;
+  line-height: 21px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  /* Hide actions by default, show on hover */
+  &:hover .chat-system-mcp-request-request-msg-bubble-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.chat-system-mcp-request-request-msg-agent {
+  margin-bottom: 4px;
+}
+.chat-system-mcp-request-request-msg-agent-label {
+  color: #BFC1D3;
+  font-family: Lato;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 21px; /* 150% */
+}
+
+.chat-system-mcp-request-request-msg-text, :deep() pre {
+  word-break: break-word;
+  white-space: pre-line;
+  list-style-position: inside;
+}
+
+.chat-system-mcp-request-request-msg-text {
+  &:deep(code) {
+    padding: initial;
+    border: initial;
+    border-radius: initial;
+    background-color: transparent;
+    color: #025937;
+  }
+
+  &:deep(ul) {
+    white-space: normal;
+    margin: 0;
+    padding-left: 1rem;
+  }
+
+  &:deep(th) {
+    text-align: left;
+  }
+
+  &:deep(pre) {
+    margin: 0;
+  }
+}
+
+.theme-dark .chat-system-mcp-request-request-msg-text :deep(code) {
+  color: #C0EFDE;
+}
+
+.chat-system-mcp-request-request-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+
+  &-buttons {
+    display: flex;
+    gap: 8px;
+  }
+}
+
+.chat-system-mcp-request-request-actions-result {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  height: 30px;
+  margin-left: auto;
+
+  &.status-confirmed {
+    .icon {
+      color: var(--success);
+    }
+  }
+
+  &.status-canceled {
+    .icon {
+      color: var(--error);
+    }
+  }
+}
+</style>

--- a/pkg/rancher-ai-ui/components/panels/Messages.vue
+++ b/pkg/rancher-ai-ui/components/panels/Messages.vue
@@ -14,6 +14,7 @@ import MessageComponent from '../message/index.vue';
 import Welcome from '../message/template/Welcome.vue';
 import NoPermission from '../message/template/NoPermissions.vue';
 import SystemRequest from '../message/template/SystemRequest.vue';
+import McpAuthenticationRequest from '../message/template/McpAuthenticationRequest.vue';
 import ScrollButton from '../ScrollButton.vue';
 import Processing from '../Processing.vue';
 import { useScrollComposable } from '../../composables/useScrollComposable';
@@ -143,6 +144,8 @@ function getMessageTemplate(component: MessageTemplateComponent) {
     return NoPermission;
   case MessageTemplateComponent.SystemRequest:
     return SystemRequest;
+  case MessageTemplateComponent.McpAuthenticationRequest:
+    return McpAuthenticationRequest;
   default:
     return null;
   }

--- a/pkg/rancher-ai-ui/components/panels/Messages.vue
+++ b/pkg/rancher-ai-ui/components/panels/Messages.vue
@@ -229,11 +229,12 @@ onBeforeUnmount(() => {
       :disabled="false"
     />
     <Processing
-      v-if="!props.disabled"
+      v-if="!props.activeChatId || !props.disabled"
+      data-test-prefix="message"
       class="chat-message-processing-label text-label"
       :class="{
         /* It avoids pushing the System messages up (Welcome template) */
-        'sticky-bottom': formattedMessages.filter((m: Message) => m.role === Role.User).length > 0
+        'sticky-bottom': !props.activeChatId || formattedMessages.filter((m: Message) => m.role === Role.User).length > 0
       }"
       :phase="props.processingState?.phase"
       :label="props.processingState?.label"

--- a/pkg/rancher-ai-ui/composables/__tests__/useChatMessageComposable.test.ts
+++ b/pkg/rancher-ai-ui/composables/__tests__/useChatMessageComposable.test.ts
@@ -596,6 +596,194 @@ describe('useChatMessageComposable', () => {
     });
   });
 
+  describe('function: wsSend', () => {
+    it('should send message when WebSocket is open', () => {
+      mockComponent = mount(createTestComponent());
+
+      const mockWs = {
+        readyState: WebSocket.OPEN,
+        send:       jest.fn()
+      } as any;
+
+      const { onopen } = mockComponent.vm;
+
+      mockStore.getters['rancher-ai-ui/chat/messageBox'] = jest.fn(() => 'Test message');
+
+      onopen({ target: mockWs } as any);
+
+      expect(mockWs.send).toHaveBeenCalled();
+    });
+
+    it('should NOT send message when WebSocket is closed', () => {
+      mockComponent = mount(createTestComponent());
+
+      const mockWs = {
+        readyState: WebSocket.CLOSED,
+        send:       jest.fn()
+      } as any;
+
+      mockStore.getters['rancher-ai-ui/chat/messageBox'] = jest.fn(() => 'Test message');
+
+      const { onopen } = mockComponent.vm;
+
+      onopen({ target: mockWs } as any);
+
+      expect(mockWs.send).not.toHaveBeenCalled();
+    });
+
+    it('should NOT send message when WebSocket is null', () => {
+      mockComponent = mount(createTestComponent());
+
+      mockStore.getters['rancher-ai-ui/chat/messageBox'] = jest.fn(() => 'Test message');
+
+      const { onopen } = mockComponent.vm;
+
+      expect(() => onopen({ target: null } as any)).not.toThrow();
+    });
+
+    it('should NOT send message when WebSocket readyState is CONNECTING', () => {
+      mockComponent = mount(createTestComponent());
+
+      const mockWs = {
+        readyState: WebSocket.CONNECTING,
+        send:       jest.fn()
+      } as any;
+
+      mockStore.getters['rancher-ai-ui/chat/messageBox'] = jest.fn(() => 'Test message');
+
+      const { onopen } = mockComponent.vm;
+
+      onopen({ target: mockWs } as any);
+
+      expect(mockWs.send).not.toHaveBeenCalled();
+    });
+
+    it('should send properly formatted message to WebSocket', () => {
+      mockComponent = mount(createTestComponent());
+
+      const mockWs = {
+        readyState: WebSocket.OPEN,
+        send:       jest.fn()
+      } as any;
+
+      const messageBoxContent = JSON.stringify({ messageContent: 'Hello World' });
+
+      mockStore.getters['rancher-ai-ui/chat/messageBox'] = jest.fn(() => messageBoxContent);
+
+      const { onopen } = mockComponent.vm;
+
+      onopen({ target: mockWs } as any);
+
+      expect(mockWs.send).toHaveBeenCalledWith(expect.any(String));
+    });
+  });
+
+  describe('function: onclose', () => {
+    it('should mark current message as completed when onclose is called', () => {
+      mockStore.getters['rancher-ai-ui/chat/message'] = jest.fn(() => ({
+        id:        'msg-1',
+        completed: false
+      }));
+      mockStore.commit.mockClear();
+
+      mockComponent = mount(createTestComponent());
+      const { onclose } = mockComponent.vm;
+
+      onclose();
+
+      expect(mockStore.commit).toHaveBeenCalledWith(
+        'rancher-ai-ui/chat/setProcessingState',
+        expect.objectContaining({ processingState: expect.objectContaining({ phase: 'idle' }) })
+      );
+    });
+
+    it('should clear message box when onclose is called', () => {
+      mockStore.commit.mockClear();
+
+      mockComponent = mount(createTestComponent());
+      const { onclose } = mockComponent.vm;
+
+      onclose();
+
+      const clearMessageBoxCalls = mockStore.commit.mock.calls.filter(
+        (call: any[]) => call[0] === 'rancher-ai-ui/chat/clearMessageBox'
+      );
+
+      expect(clearMessageBoxCalls.length).toBeGreaterThan(0);
+    });
+
+    it('should set processing state to idle on close', () => {
+      mockStore.commit.mockClear();
+
+      mockComponent = mount(createTestComponent());
+      const { onclose } = mockComponent.vm;
+
+      onclose();
+
+      expect(mockStore.commit).toHaveBeenCalledWith(
+        'rancher-ai-ui/chat/setProcessingState',
+        expect.objectContaining({ processingState: expect.objectContaining({ phase: 'idle' }) })
+      );
+    });
+
+    it('should handle gracefully when no current message exists', () => {
+      mockStore.getters['rancher-ai-ui/chat/message'] = jest.fn(() => null);
+
+      mockComponent = mount(createTestComponent());
+      const { onclose } = mockComponent.vm;
+
+      expect(() => onclose()).not.toThrow();
+
+      expect(mockStore.commit).toHaveBeenCalledWith(
+        'rancher-ai-ui/chat/setProcessingState',
+        expect.objectContaining({ processingState: expect.objectContaining({ phase: 'idle' }) })
+      );
+    });
+
+    it('should abort pending authentication requests on close', () => {
+      mockComponent = mount(createTestComponent());
+      const { onclose } = mockComponent.vm;
+
+      mockStore.commit.mockClear();
+
+      onclose();
+
+      expect(mockStore.commit).toHaveBeenCalled();
+    });
+
+    it('should transition to idle phase from various processing states', () => {
+      mockStore.getters['rancher-ai-ui/chat/processingState'] = jest.fn(() => ({ phase: 'processing' }));
+      mockStore.commit.mockClear();
+
+      mockComponent = mount(createTestComponent());
+      const { onclose } = mockComponent.vm;
+
+      onclose();
+
+      expect(mockStore.commit).toHaveBeenCalledWith(
+        'rancher-ai-ui/chat/setProcessingState',
+        expect.objectContaining({ processingState: expect.objectContaining({ phase: 'idle' }) })
+      );
+    });
+
+    it('should complete WebSocket session properly', async() => {
+      mockStore.getters['rancher-ai-ui/chat/message'] = jest.fn(() => ({
+        id:        'msg-1',
+        completed: false
+      }));
+      mockStore.commit.mockClear();
+
+      mockComponent = mount(createTestComponent());
+      const { onclose } = mockComponent.vm;
+
+      await onclose();
+
+      const commitCalls = mockStore.commit.mock.calls;
+
+      expect(commitCalls.length).toBeGreaterThan(0);
+    });
+  });
+
   describe('function: onopen', () => {
     it('should send message via WebSocket when messageBox has content', () => {
       const messageBoxContent = JSON.stringify({ messageContent: 'User query' });
@@ -607,8 +795,9 @@ describe('useChatMessageComposable', () => {
       const { onopen } = mockComponent.vm;
 
       const mockWs = {
-        send:  jest.fn(),
-        close: jest.fn()
+        readyState: WebSocket.OPEN,
+        send:       jest.fn(),
+        close:      jest.fn()
       } as any;
 
       onopen({ target: mockWs } as any);
@@ -625,8 +814,9 @@ describe('useChatMessageComposable', () => {
       const { onopen } = mockComponent.vm;
 
       const mockWs = {
-        send:  jest.fn(),
-        close: jest.fn()
+        readyState: WebSocket.OPEN,
+        send:       jest.fn(),
+        close:      jest.fn()
       } as any;
 
       onopen({ target: mockWs } as any);
@@ -657,8 +847,9 @@ describe('useChatMessageComposable', () => {
       const { onopen } = mockComponent.vm;
 
       const mockWs = {
-        send:  jest.fn(),
-        close: jest.fn()
+        readyState: WebSocket.OPEN,
+        send:       jest.fn(),
+        close:      jest.fn()
       } as any;
 
       onopen({ target: mockWs } as any);

--- a/pkg/rancher-ai-ui/composables/__tests__/useChatMessageComposable.test.ts
+++ b/pkg/rancher-ai-ui/composables/__tests__/useChatMessageComposable.test.ts
@@ -10,6 +10,7 @@ let mockStore: any;
 let mockComponent: any;
 
 jest.mock('vuex', () => ({ useStore: () => mockStore }));
+jest.mock('../../utils/log', () => ({ warn: jest.fn() }));
 
 // Helper: Create a real Vue component that uses the composable
 function createTestComponent(setupData?: any) {
@@ -518,6 +519,36 @@ describe('useChatMessageComposable', () => {
       mockComponent = mount(createTestComponent({ agentName }));
 
       expect(mockComponent.vm).toBeDefined();
+    });
+
+    it('should handle invalid auth URL in metadata', async() => {
+      mockStore.getters['rancher-ai-ui/chat/metadata'] = {
+        chatId: 'chat-1',
+        agents: []
+      };
+      mockStore.getters['rancher-ai-ui/chat/message'] = jest.fn(() => ({
+        id:        'msg-1',
+        completed: false
+      }));
+
+      mockComponent = mount(createTestComponent());
+      mockStore.dispatch.mockClear();
+      mockStore.commit.mockClear();
+
+      await mockComponent.vm.onmessage({
+        target: {} as WebSocket,
+        data:   '<authentication>{"url":"invalid","agent":"test"}</authentication>'
+      } as any);
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith(
+        'rancher-ai-ui/chat/addMessage',
+        expect.objectContaining({
+          message: expect.objectContaining({
+            source:         'error',
+            messageContent: '%ai.error.message% %ai.error.oauth2.invalidMetadata%'
+          })
+        })
+      );
     });
   });
 

--- a/pkg/rancher-ai-ui/composables/useAIAgentApiComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useAIAgentApiComposable.ts
@@ -2,7 +2,7 @@ import { ComputedRef } from 'vue';
 import { AGENT_NAME, AGENT_NAMESPACE, AGENT_REST_API_PATH } from '../product';
 import { error } from '../utils/log';
 import {
-  Agent, AgentSettings, Context, HistoryChat, HistoryChatMessage, LLMProvider, Message,
+  Agent, AgentSettings, AiAgentAPIEvent, Context, HistoryChat, HistoryChatMessage, LLMProvider, Message,
   ToolCall,
   ToolsConfig,
 } from '../types';
@@ -18,6 +18,21 @@ interface LLMOptions {
 interface LLMConfig {
   name: LLMProvider;
   options: LLMOptions;
+}
+
+interface McpAuthenticationMetadata {
+  metadataEndpoint?: string;
+  scopesSupported?: string[];
+}
+
+interface McpAuthenticationClientInfo {
+  clientId?: string;
+  clientSecret?: string;
+}
+
+interface McpAuthenticationEvent {
+  code?: AiAgentAPIEvent.Abort | AiAgentAPIEvent.Error;
+  message?: string;
 }
 
 interface UIToolsCallsPayload {
@@ -42,13 +57,16 @@ interface UIToolsCallsPayload {
 
 export function useAIAgentApiComposable(agents?: ComputedRef<Agent[]>) {
   const apiPath = `/api/v1/namespaces/${ AGENT_NAMESPACE }/services/http:${ AGENT_NAME }:80/proxy/${ AGENT_REST_API_PATH }`;
+
   let llmModelsAbortController: AbortController | null = null;
+  let mcpAuthenticationMetadataAbortController: AbortController | null = null;
+  let mcpAuthenticationClientInfoAbortController: AbortController | null = null;
+
+  const mcpScopesCache: Record<string, string[]> = {};
 
   async function fetchLLMModels(llmConfig: LLMConfig): Promise<string[]> {
-    // Abort and refresh the AbortController for fetching LLM models
-    if (llmModelsAbortController) {
-      llmModelsAbortController.abort();
-    }
+    cancelFetchLLMModels();
+
     llmModelsAbortController = new AbortController();
 
     const queryParams = new URLSearchParams();
@@ -86,6 +104,153 @@ export function useAIAgentApiComposable(agents?: ComputedRef<Agent[]>) {
     }
 
     return await data.json() as string[];
+  }
+
+  function cancelFetchLLMModels() {
+    if (llmModelsAbortController) {
+      llmModelsAbortController.abort();
+    }
+  }
+
+  async function refreshMcpAuthenticationToken(agent: string) {
+    try {
+      const data = await fetch(`${ apiPath }/oauth2/refresh`, {
+        method:      'POST',
+        credentials: 'same-origin',
+        body:        JSON.stringify({ agent }),
+        headers:     { 'Content-Type': 'application/json' },
+      });
+
+      if (!data.ok) {
+        const errorMessage = await data.text();
+
+        throw new Error(errorMessage);
+      }
+
+      return;
+    } catch (err) {
+      error('Failed to trigger MCP authentication token refresh:', err);
+
+      throw err;
+    }
+  }
+
+  async function fetchMcpAuthenticationMetadata(args: { mcpUrl: string, abort?: boolean } = {
+    mcpUrl: '',
+    abort:  true
+  }): Promise<McpAuthenticationMetadata & McpAuthenticationEvent | null> {
+    const { mcpUrl, abort } = args;
+
+    if (abort) {
+      cancelFetchMcpAuthenticationMetadata();
+    }
+
+    mcpAuthenticationMetadataAbortController = new AbortController();
+
+    try {
+      const queryParams = new URLSearchParams();
+
+      queryParams.append('mcpUrl', mcpUrl);
+
+      const data = await fetch(`${ apiPath }/oauth2/metadata?${ queryParams.toString() }`, { signal: mcpAuthenticationMetadataAbortController.signal });
+
+      if (!data.ok) {
+        const errorMessage = await data.text();
+
+        throw new Error(errorMessage);
+      }
+
+      const metadata = await data.json() as McpAuthenticationMetadata;
+
+      if (metadata?.scopesSupported) {
+        mcpScopesCache[mcpUrl] = metadata.scopesSupported;
+      }
+
+      return metadata;
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return { code: AiAgentAPIEvent.Abort };
+      }
+
+      error('Failed to fetch MCP authentication metadata:', err);
+
+      return {
+        code:    AiAgentAPIEvent.Error,
+        message: (err as Error).message || ''
+      };
+    }
+  }
+
+  function cancelFetchMcpAuthenticationMetadata() {
+    if (mcpAuthenticationMetadataAbortController) {
+      mcpAuthenticationMetadataAbortController.abort();
+    }
+  }
+
+  async function fetchMcpAuthenticationScopes(args: { mcpUrl: string }): Promise<string[]> {
+    const { mcpUrl } = args;
+
+    if (mcpScopesCache[mcpUrl]) {
+      return mcpScopesCache[mcpUrl];
+    }
+
+    const metadata = await fetchMcpAuthenticationMetadata({
+      mcpUrl,
+      abort: false
+    });
+
+    if (!!metadata?.scopesSupported) {
+      return metadata.scopesSupported;
+    }
+
+    return [];
+  }
+
+  async function fetchMcpAuthenticationClientInfo(args: { metadataEndpoint: string, abort?: boolean } = {
+    metadataEndpoint: '',
+    abort:            true
+  }): Promise<McpAuthenticationClientInfo & McpAuthenticationEvent | null> {
+    const { metadataEndpoint, abort } = args;
+
+    if (abort) {
+      cancelFetchMcpAuthenticationClientInfo();
+    }
+
+    mcpAuthenticationClientInfoAbortController = new AbortController();
+
+    try {
+      const data = await fetch(`${ apiPath }/oauth2/dynamic-registration`, {
+        method:  'POST',
+        body:    JSON.stringify({ metadataEndpoint }),
+        headers: { 'Content-Type': 'application/json' },
+        signal:  mcpAuthenticationClientInfoAbortController.signal,
+      });
+
+      if (!data.ok) {
+        const errorMessage = await data.text();
+
+        throw new Error(errorMessage);
+      }
+
+      return await data.json() as McpAuthenticationClientInfo;
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return { code: AiAgentAPIEvent.Abort };
+      }
+
+      error('Failed to fetch MCP authentication client info:', err);
+
+      return {
+        code:    AiAgentAPIEvent.Error,
+        message: (err as Error).message || ''
+      };
+    }
+  }
+
+  function cancelFetchMcpAuthenticationClientInfo() {
+    if (mcpAuthenticationClientInfoAbortController) {
+      mcpAuthenticationClientInfoAbortController.abort();
+    }
   }
 
   async function fetchSettings(): Promise<AgentSettings | null> {
@@ -234,6 +399,12 @@ export function useAIAgentApiComposable(agents?: ComputedRef<Agent[]>) {
   }
 
   return {
+    refreshMcpAuthenticationToken,
+    fetchMcpAuthenticationMetadata,
+    cancelFetchMcpAuthenticationMetadata,
+    fetchMcpAuthenticationClientInfo,
+    cancelFetchMcpAuthenticationClientInfo,
+    fetchMcpAuthenticationScopes,
     fetchLLMModels,
     fetchSettings,
     saveSettings,

--- a/pkg/rancher-ai-ui/composables/useAIAgentApiComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useAIAgentApiComposable.ts
@@ -2,7 +2,7 @@ import { ComputedRef } from 'vue';
 import { AGENT_NAME, AGENT_NAMESPACE, AGENT_REST_API_PATH } from '../product';
 import { error } from '../utils/log';
 import {
-  Agent, AgentSettings, AiAgentAPIEvent, Context, HistoryChat, HistoryChatMessage, LLMProvider, Message,
+  Agent, AgentSettings, AIAgentAPIEvent, Context, HistoryChat, HistoryChatMessage, LLMProvider, Message,
   ToolCall,
   ToolsConfig,
 } from '../types';
@@ -31,7 +31,7 @@ interface McpAuthenticationClientInfo {
 }
 
 interface McpAuthenticationEvent {
-  code?: AiAgentAPIEvent.Abort | AiAgentAPIEvent.Error;
+  code?: AIAgentAPIEvent.Abort | AIAgentAPIEvent.Error;
   message?: string;
 }
 
@@ -169,13 +169,13 @@ export function useAIAgentApiComposable(agents?: ComputedRef<Agent[]>) {
       return metadata;
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') {
-        return { code: AiAgentAPIEvent.Abort };
+        return { code: AIAgentAPIEvent.Abort };
       }
 
       error('Failed to fetch MCP authentication metadata:', err);
 
       return {
-        code:    AiAgentAPIEvent.Error,
+        code:    AIAgentAPIEvent.Error,
         message: (err as Error).message || ''
       };
     }
@@ -235,13 +235,13 @@ export function useAIAgentApiComposable(agents?: ComputedRef<Agent[]>) {
       return await data.json() as McpAuthenticationClientInfo;
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') {
-        return { code: AiAgentAPIEvent.Abort };
+        return { code: AIAgentAPIEvent.Abort };
       }
 
       error('Failed to fetch MCP authentication client info:', err);
 
       return {
-        code:    AiAgentAPIEvent.Error,
+        code:    AIAgentAPIEvent.Error,
         message: (err as Error).message || ''
       };
     }

--- a/pkg/rancher-ai-ui/composables/useAgentComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useAgentComposable.ts
@@ -1,8 +1,9 @@
-import { computed, onMounted } from 'vue';
+import { computed } from 'vue';
 import { useStore } from 'vuex';
 import { RANCHER_AI_SCHEMA } from '../product';
 import { Agent, AIAgentConfigCRD } from '../types';
 import { formatAgentFromCRD } from '../utils/format';
+import { error } from '../utils/log';
 
 export const DEFAULT_AI_AGENT = 'rancher';
 
@@ -24,7 +25,12 @@ export function useAgentComposable(chatId: string) {
 
   async function fetchAgents() {
     if (store.getters['management/canList'](RANCHER_AI_SCHEMA.AI_AGENT_CONFIG)) {
-      await store.dispatch('management/findAll', { type: RANCHER_AI_SCHEMA.AI_AGENT_CONFIG });
+      // This can throw errors if called in the middle of server redeployments
+      try {
+        await store.dispatch('management/findAll', { type: RANCHER_AI_SCHEMA.AI_AGENT_CONFIG });
+      } catch (err) {
+        error('Failed to fetch AI agents:', err);
+      }
     }
   }
 
@@ -35,13 +41,10 @@ export function useAgentComposable(chatId: string) {
     });
   }
 
-  onMounted(() => {
-    fetchAgents();
-  });
-
   return {
     agents,
-    selectAgent,
     agentName,
+    fetchAgents,
+    selectAgent,
   };
 }

--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -405,7 +405,7 @@ export function useChatMessageComposable(
       try {
         await processMessageData(ws, data);
       } catch (err) {
-        processMessageErrorData(err as Error);
+        processMessageErrorData(err as ChatError);
       }
     }
   }

--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -88,7 +88,7 @@ export function useChatMessageComposable(
 
   const error = computed(() => store.getters['rancher-ai-ui/chat/error'](chatId));
 
-  const processingState = computed(() => store.getters['rancher-ai-ui/chat/processingState'](chatId) || { phase: MessagePhase.Initializing });
+  const processingState = computed(() => store.getters['rancher-ai-ui/chat/processingState'](chatId));
 
   const setProcessingState = (processingState: MessageProcessingState) => {
     store.commit('rancher-ai-ui/chat/setProcessingState', {
@@ -414,9 +414,9 @@ export function useChatMessageComposable(
       currentMsg.value.completed = true;
     }
 
-    clearMessageBox();
-
     AuthenticationHandler.abortPendingRequests();
+
+    clearMessageBox();
 
     setProcessingState({ phase: MessagePhase.Idle });
   }

--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -1,4 +1,6 @@
-import { ref, computed, onMounted, ComputedRef } from 'vue';
+import {
+  ref, computed, onMounted, ComputedRef, onBeforeUnmount
+} from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import { NORMAN } from '@shell/config/types';
@@ -11,6 +13,9 @@ import {
   ChatMetadata,
   ConfirmationResponse,
   ConfirmationStatus,
+  McpAuthenticationRequest,
+  McpAuthenticationResponse,
+  McpTokenRefreshResponse,
   Message,
   MessageAction,
   MessageInternalSource,
@@ -32,11 +37,15 @@ import {
   formatTools,
   formatSubAgentProcessingMetadata,
   formatAgentMetadata,
+  formatMcpAuthenticationRequest,
+  formatMcpRefreshTokenRequest,
+  formatAuthenticationErrorMessage
 } from '../utils/format';
 import { downloadFile } from '@shell/utils/download';
 import { useContextComposable } from './useContextComposable';
 import { useAIAgentApiComposable } from './useAIAgentApiComposable';
 import { useToolsComposable } from './useToolsComposable';
+import AuthenticationHandler from '../handlers/authentication';
 
 const EXPAND_THINKING = false;
 
@@ -65,17 +74,19 @@ export function useChatMessageComposable(
 
   const { selectContext, selectedContext } = useContextComposable();
   const { toolsSelector } = useToolsComposable();
-  const { fetchUIToolsCalls } = useAIAgentApiComposable();
+  const { refreshMcpAuthenticationToken, fetchUIToolsCalls } = useAIAgentApiComposable();
 
   const principal = store.getters['rancher/byId'](NORMAN.PRINCIPAL, store.getters['auth/principalId']) || {};
 
-  const messageBox = computed(() => store.getters['rancher-ai-ui/chat/messageBox'](chatId));
-  const messages = computed(() => Object.values(store.getters['rancher-ai-ui/chat/messages'](chatId)) as Message[]);
   const currentMsg = ref<Message>({} as Message);
-  const error = computed(() => store.getters['rancher-ai-ui/chat/error'](chatId));
 
   const chatMetadata = computed<ChatMetadata>(() => store.getters['rancher-ai-ui/chat/metadata'] || {});
   const isChatInitialized = computed(() => !!chatMetadata.value.chatId);
+
+  const messageBox = computed(() => store.getters['rancher-ai-ui/chat/messageBox'](chatId));
+  const messages = computed(() => Object.values(store.getters['rancher-ai-ui/chat/messages'](chatId)) as Message[]);
+
+  const error = computed(() => store.getters['rancher-ai-ui/chat/error'](chatId));
 
   const processingState = computed(() => store.getters['rancher-ai-ui/chat/processingState'](chatId) || { phase: MessagePhase.Initializing });
 
@@ -87,7 +98,7 @@ export function useChatMessageComposable(
   };
 
   function wsSend(ws: WebSocket, value: string) {
-    if (!ws) {
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
       return;
     }
 
@@ -296,6 +307,63 @@ export function useChatMessageComposable(
     }
   }
 
+  async function ensureAgentMcpAuthenticationRequest(ws: WebSocket, agents: Agent[], metadata: McpAuthenticationRequest) {
+    const agent = agents.find((a) => a.name === metadata?.agent);
+
+    if (agent) {
+      const content = {
+        agent,
+        message: t('ai.message.system.agentTokenRefresh.info', {}, true)
+      };
+      const actions = [
+        {
+          label:  t('ai.message.system.agentTokenRefresh.actions.confirm'),
+          type:   ActionType.Button,
+          action: () => {
+            AuthenticationHandler.createOauth2AuthenticationRequest(
+              metadata,
+              () => resolveOauth2Authentication(ws, McpAuthenticationResponse.Continue, MessagePhase.ResumingAgent),
+              () => resolveOauth2Authentication(ws, McpAuthenticationResponse.Cancel, MessagePhase.Idle)
+            );
+
+            return {
+              label:  t('ai.message.system.agentTokenRefresh.results.confirm', {}, true),
+              status: ConfirmationStatus.Confirmed,
+              icon:   'icon-checkmark'
+            };
+          },
+        },
+        {
+          label:  t('ai.message.system.agentTokenRefresh.actions.dismiss'),
+          type:   ActionType.Button,
+          action: () => {
+            resolveOauth2Authentication(ws, McpAuthenticationResponse.Cancel, MessagePhase.Idle);
+
+            return {
+              label:   t('ai.message.system.agentTokenRefresh.results.dismiss', {}, true),
+              status:  ConfirmationStatus.Canceled,
+              icon:    'icon-close'
+            };
+          },
+        }
+      ];
+
+      const message = buildSystemRequestMessage({
+        component: MessageTemplateComponent.McpAuthenticationRequest,
+        content,
+        actions
+      });
+
+      await addMessage(message);
+    }
+  }
+
+  function resolveOauth2Authentication(ws: WebSocket, response: McpAuthenticationResponse, nextPhase: MessagePhase) {
+    wsSend(ws, response);
+
+    setProcessingState({ phase: nextPhase });
+  }
+
   function onopen(event: { target: WebSocket }) {
     const ws = event.target;
 
@@ -310,6 +378,7 @@ export function useChatMessageComposable(
   }
 
   async function onmessage(event: MessageEvent) {
+    const ws = event.target as WebSocket;
     const data = event.data;
 
     if (!isChatInitialized.value) {
@@ -333,7 +402,7 @@ export function useChatMessageComposable(
       }
     } else {
       try {
-        await processMessageData(data);
+        await processMessageData(ws, data);
       } catch (err) {
         processMessageErrorData(err as Error);
       }
@@ -346,6 +415,8 @@ export function useChatMessageComposable(
     }
 
     clearMessageBox();
+
+    AuthenticationHandler.abortPendingRequests();
 
     setProcessingState({ phase: MessagePhase.Idle });
   }
@@ -417,7 +488,7 @@ export function useChatMessageComposable(
     }
   }
 
-  async function processMessageData(data: string) {
+  async function processMessageData(ws: WebSocket, data: string) {
     switch (data) {
     case Tag.MessageStart:
       setProcessingState({ phase: MessagePhase.Working });
@@ -449,12 +520,16 @@ export function useChatMessageComposable(
       setProcessingState({ phase: MessagePhase.GeneratingResponse });
 
       if (data.startsWith(Tag.ProcessingSubagentInitStart) && data.endsWith(Tag.ProcessingSubagentInitEnd)) {
-        const metadata = formatSubAgentProcessingMetadata(data, agents.value);
+        const metadata = formatSubAgentProcessingMetadata(data);
 
-        if (metadata) {
+        const agent = agents.value.find((a) => a.name === metadata?.name);
+
+        const agentName = agent?.displayName || metadata?.name;
+
+        if (metadata && agentName) {
           setProcessingState({
             phase: MessagePhase.ProcessingSubagent,
-            label: `${ metadata.agent }: ${ metadata.query?.slice(0, 100) || t('ai.processing.label.default') }`
+            label: `${ agentName }: ${ metadata.query?.slice(0, 100) || t('ai.processing.label.default') }`
           });
         }
         break;
@@ -470,6 +545,40 @@ export function useChatMessageComposable(
         if (metadata && currentMsg.value.agentMetadata) {
           currentMsg.value.agentMetadata.recommended = metadata.recommended;
         }
+        break;
+      }
+
+      if (data.startsWith(Tag.AuthenticationRequestStart) && data.endsWith(Tag.AuthenticationRequestEnd)) {
+        const metadata = formatMcpAuthenticationRequest(data);
+
+        if (!metadata || !metadata.url) {
+          throw {
+            message: 'Invalid authentication request metadata',
+            key:     'message'
+          };
+        }
+
+        await ensureAgentMcpAuthenticationRequest(ws, agents.value, metadata);
+
+        setProcessingState({
+          phase: MessagePhase.AwaitingConfirmation,
+          label: t('ai.processing.label.authenticationRequired')
+        });
+
+        break;
+      }
+
+      if (data.startsWith(Tag.TokenRefreshRequestStart) && data.endsWith(Tag.TokenRefreshRequestEnd)) {
+        const agentName = formatMcpRefreshTokenRequest(data);
+
+        if (agentName) {
+          await refreshMcpAuthenticationToken(agentName);
+
+          wsSend(ws, McpTokenRefreshResponse.Confirm);
+
+          setProcessingState({ phase: MessagePhase.RefreshingMcpToken });
+        }
+
         break;
       }
 
@@ -520,9 +629,21 @@ export function useChatMessageComposable(
         }
 
         if (data.startsWith(Tag.ErrorStart) && data.endsWith(Tag.ErrorEnd)) {
-          const errorMessage = formatErrorMessage(data);
+          const err = formatErrorMessage(data);
 
-          throw errorMessage;
+          throw {
+            message: err.message,
+            key:     'message'
+          };
+        }
+
+        if (data.startsWith(Tag.AuthenticationErrorStart) && data.endsWith(Tag.AuthenticationErrorEnd)) {
+          const err = formatAuthenticationErrorMessage(data);
+
+          throw {
+            message: err.message,
+            key:     'authentication'
+          };
         }
 
         if (data === Tag.ProcessingTools) {
@@ -548,12 +669,14 @@ export function useChatMessageComposable(
     }
   }
 
-  function processMessageErrorData(error: Error) {
+  function processMessageErrorData(error: ChatError) {
     setProcessingState({ phase: MessagePhase.Idle });
+
+    const prefix = t(`ai.error.${ error.key || 'message' }`, {}, true);
 
     addMessage({
       role:           Role.System,
-      messageContent: `${ t('ai.error.message.processing') } ${ error.message || '' }`,
+      messageContent: `${ prefix } ${ error.message || '' }`,
       timestamp:      new Date(),
       completed:      true,
       source:         MessageInternalSource.Error,
@@ -602,6 +725,10 @@ export function useChatMessageComposable(
       chatId,
       messages: hasPermissions.value ? [] : [buildNoPermissionMessage()]
     });
+  });
+
+  onBeforeUnmount(() => {
+    AuthenticationHandler.abortPendingRequests();
   });
 
   return {

--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -41,6 +41,7 @@ import {
   formatMcpRefreshTokenRequest,
   formatAuthenticationErrorMessage
 } from '../utils/format';
+import { validateUrl } from '../utils/url';
 import { downloadFile } from '@shell/utils/download';
 import { useContextComposable } from './useContextComposable';
 import { useAIAgentApiComposable } from './useAIAgentApiComposable';
@@ -551,9 +552,9 @@ export function useChatMessageComposable(
       if (data.startsWith(Tag.AuthenticationRequestStart) && data.endsWith(Tag.AuthenticationRequestEnd)) {
         const metadata = formatMcpAuthenticationRequest(data);
 
-        if (!metadata || !metadata.url) {
+        if (!metadata || !validateUrl(metadata.url)) {
           throw {
-            message: 'Invalid authentication request metadata',
+            message: t('ai.error.oauth2.invalidMetadata'),
             key:     'message'
           };
         }

--- a/pkg/rancher-ai-ui/handlers/authentication.ts
+++ b/pkg/rancher-ai-ui/handlers/authentication.ts
@@ -10,7 +10,7 @@ const OAUTH2_SUCCESS_MESSAGE = 'oauth_success';
 class OAuth2AuthenticationRequest {
   private window: Window | null;
   private broadcastChannel: BroadcastChannel | null = null;
-  private clearCloseInterval: any;
+  private clearCloseInterval: NodeJS.Timeout | null = null; // eslint-disable-line no-undef
 
   private isCompleted: boolean = false;
 
@@ -48,7 +48,11 @@ class OAuth2AuthenticationRequest {
 
     this.clearCloseInterval = setInterval(() => {
       if (!authWindow || authWindow.closed) {
-        clearInterval(this.clearCloseInterval);
+        if (this.clearCloseInterval) {
+          clearInterval(this.clearCloseInterval);
+
+          this.clearCloseInterval = null;
+        }
 
         if (!this.isCompleted) {
           this.cancelFn();

--- a/pkg/rancher-ai-ui/handlers/authentication.ts
+++ b/pkg/rancher-ai-ui/handlers/authentication.ts
@@ -67,6 +67,8 @@ class OAuth2AuthenticationRequest {
     if (this.clearCloseInterval) {
       clearInterval(this.clearCloseInterval);
 
+      this.clearCloseInterval = null;
+
       if (args?.notify) {
         this.cancelFn();
       }

--- a/pkg/rancher-ai-ui/handlers/authentication.ts
+++ b/pkg/rancher-ai-ui/handlers/authentication.ts
@@ -1,0 +1,132 @@
+import { markRaw } from 'vue';
+import { McpAuthenticationRequest } from '../types';
+
+const OAUTH2_CHANNEL_NAME = 'oauth_channel';
+const OAUTH2_SUCCESS_MESSAGE = 'oauth_success';
+
+/**
+ * Handles OAuth2 authentication requests.
+ */
+class OAuth2AuthenticationRequest {
+  private window: Window | null;
+  private broadcastChannel: BroadcastChannel | null = null;
+  private clearCloseInterval: any;
+
+  private isCompleted: boolean = false;
+
+  private resolveFn: () => void;
+  private cancelFn: () => void;
+
+  constructor(metadata: McpAuthenticationRequest, resolveFn: () => void, cancelFn: () => void) {
+    this.resolveFn = resolveFn;
+    this.cancelFn = cancelFn;
+
+    const authWindow = window.open(metadata.url, `auth_${ metadata.type }`, 'width=600,height=700,left=200,top=200');
+
+    if (authWindow) {
+      const channel = new BroadcastChannel(OAUTH2_CHANNEL_NAME);
+
+      channel.onmessage = (event) => {
+        if (event.data && event.data.type === OAUTH2_SUCCESS_MESSAGE) {
+          this.isCompleted = true;
+          this.resolveFn();
+
+          channel.close();
+        }
+      };
+
+      channel.onmessageerror = () => {
+        this.cancelFn();
+
+        channel.close();
+      };
+
+      this.broadcastChannel = channel;
+    } else {
+      this.cancelFn();
+    }
+
+    this.clearCloseInterval = setInterval(() => {
+      if (!authWindow || authWindow.closed) {
+        clearInterval(this.clearCloseInterval);
+
+        if (!this.isCompleted) {
+          this.cancelFn();
+        }
+      }
+    }, 500);
+
+    this.window = authWindow;
+  }
+
+  public abort(args = { notify: true }): void {
+    if (this.clearCloseInterval) {
+      clearInterval(this.clearCloseInterval);
+
+      if (args?.notify) {
+        this.cancelFn();
+      }
+    }
+
+    if (this.broadcastChannel) {
+      this.broadcastChannel.close();
+    }
+
+    if (this.window && !this.window.closed) {
+      this.window.close();
+    }
+  }
+}
+
+/**
+ * Handles authentication requests
+ *
+ * - Manages the state of active OAuth2 requests.
+ * - Other authentication methods can be added in the future.
+ */
+class AuthenticationHandler {
+  private activeOauth2Request: OAuth2AuthenticationRequest | null = null;
+
+  /**
+   *
+   * @param metadata the metdata payload for the popup window
+   * @param resolveFn the method to call to proceed with authentication
+   * @param cancelFn  the method to call to cancel the authentication
+   *
+   * @returns an instance of OAuth2AuthenticationRequest
+   *
+   * This method creates a new OAuth2 authentication request.
+   * If there's an existing active request, it aborts it before creating a new one.
+   */
+  createOauth2AuthenticationRequest(
+    metadata: McpAuthenticationRequest,
+    resolveFn: () => void,
+    cancelFn: () => void
+  ): OAuth2AuthenticationRequest {
+    if (this.activeOauth2Request) {
+      this.activeOauth2Request.abort({ notify: false });
+    }
+
+    this.activeOauth2Request = markRaw(new OAuth2AuthenticationRequest(metadata, resolveFn, cancelFn));
+
+    return this.activeOauth2Request;
+  }
+
+  /**
+   * Other authentication methods can be added here in the future, following a similar pattern to the OAuth2 method above.
+   */
+
+  /**
+   * Aborts any pending authentication requests.
+   * As of now, it only handles OAuth2 requests, but this can be extended in the future to handle other authentication methods.
+   */
+  abortPendingRequests(): void {
+    if (this.activeOauth2Request) {
+      this.activeOauth2Request.abort();
+    }
+
+    this.activeOauth2Request = null;
+  }
+}
+
+export default new AuthenticationHandler();

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -206,6 +206,8 @@ ai:
       generic: 'An error occurred initializing the chat'
     message: 'Error processing message: '
     authentication: 'Authentication error: '
+    oauth2:
+      invalidMetadata: 'Invalid authentication request metadata'
     websocket:
       generic: WebSocket error occurred. Please check the status of the Rancher AI Agent and ensure you have the necessary permissions to establish a connection to it.
       connection: Failed to connect to Rancher AI Agent.

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -433,6 +433,13 @@ aiConfig:
                     =1 { {count} scope available (optional) }
                     other { {count} scopes to choose from (optional) }
                   }
+            helper:
+              title: App Configuration
+              tooltip: 'Copy and paste these URLs when setting up your OAuth2 application with the third-party provider.'
+            homepageUrl:
+              label: Homepage URL
+            callbackUrl:
+              label: Callback URL
           mcpURL:
             label: MCP Endpoint
             placeholder: https://endpoint.mcp

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -567,7 +567,7 @@ aiConfig:
       description: The URL where your Ollama instance is hosted
     OPENAI_URL:
       label: OpenAI Third-Party URL
-      description: (Deprecated) The URL of a third-party OpenAI-compatible service, e.g., Azure or Evroc - Try to use the "Custom" option instead, which supports any OpenAI-compatible provider.
+      description: '(Deprecated) The URL of a third-party OpenAI-compatible service, e.g., Azure or Evroc - Try to use the "Custom" option instead, which supports any OpenAI-compatible provider.'
     OPENAI_API_KEY:
       label: OpenAI Key
       description: The key to authenticate requests to OpenAI’s services

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -46,7 +46,7 @@ ai:
           confirm: 'Continue'
           dismiss: 'Cancel'
         results:
-          confirm: Authentication window open
+          confirm: Authentication window opened
           dismiss: Canceled
       noPermission:
         info: 'You do not have permission to access the Rancher AI Assistant. Please contact your administrator or refer to our <docsUrl>documentation</docsUrl>'
@@ -394,7 +394,7 @@ aiConfig:
           authentication:
             title: Authentication
           authenticationType:
-            label: Type
+            label: Authentication Type
           authenticationSecret:
             label: Secret
           caBundleRef:
@@ -406,17 +406,17 @@ aiConfig:
               label: Metadata endpoint
               placeholder: Enter a valid URL
               discoverInfo:
-                info: 'Try to <action>automatically discover the metadata endpoint</action> below based on the <b>MCP endpoint</b> URL.'
-                inProgress: 'Metadata endpoint discovery is now in progress... <action>Cancel</action>'
-                success: 'The metadata endpoint was successfully retrieved and filled it automatically. <action>Run it again</action>.'
-                warning: 'Based on the current <b>MCP endpoint</b> URL, the metadata endpoint could not be retrieved automatically.<message></message><br>Please review it and <action>Try again.</action>'
+                info: 'Try to <action>automatically discover the metadata endpoint and scope details</action> below based on the <b>MCP endpoint</b> URL.'
+                inProgress: 'Metadata endpoint and scope details discovery is now in progress... <action>Cancel</action>'
+                success: 'The metadata endpoint and scope details were successfully retrieved and filled it automatically. <action>Run it again</action>.'
+                warning: 'Based on the current <b>MCP endpoint</b> URL, the metadata endpoint and scope details could not be retrieved automatically.<message></message><br>Please review it and <action>Try again.</action>'
                 message: '<br>{message}<br>'
             client:
               discoverInfo:
-                info: 'Try to <action>automatically discover the client registration and the scope details</action> below based on the <b>Metadata endpoint</b> URL.'
-                inProgress: 'Client registration and scope details discovery is now in progress... <action>Cancel</action>'
-                success: 'The client registration and the scope details were successfully retrieved and filled it automatically. <action>Run it again</action>.'
-                warning: 'Based on the current <b>Metadata endpoint</b> URL, the client registration and the scope details could not be retrieved automatically.<message></message><br>Please review it and <action>Try again.</action>'
+                info: 'Try to <action>automatically discover the client registration details</action> below based on the <b>metadata endpoint</b> URL.'
+                inProgress: 'Client registration details discovery is now in progress... <action>Cancel</action>'
+                success: 'The client registration details were successfully retrieved and filled it automatically. <action>Run it again</action>.'
+                warning: 'Based on the current <b>metadata endpoint</b> URL, the client registration details could not be retrieved automatically.<message></message><br>Please review it and <action>Try again.</action>'
                 message: '<br>{message}<br>'
             clientId:
               label: Client ID
@@ -434,7 +434,7 @@ aiConfig:
                     other { {count} scopes to choose from (optional) }
                   }
           mcpURL:
-            label: Endpoint
+            label: MCP Endpoint
             placeholder: https://endpoint.mcp
           humanValidationTools:
             addLabel: Add Validation Tool

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -40,6 +40,14 @@ ai:
         results:
           confirm: Switched to <code>{agent}</code> Agent
           dismiss: Keeping adaptive selection
+      agentTokenRefresh:
+        info: '<b>The tool you have selected requires authentication</b>. This is normal, especially for short-lived tokens.<br><br>Before you continue, <b>make sure your browser allows popups</b> - the authentication will open in a new browser window.<br><br>Once you log in, I’ll resume my response automatically...'
+        actions:
+          confirm: 'Continue'
+          dismiss: 'Cancel'
+        results:
+          confirm: Authentication window open
+          dismiss: Canceled
       noPermission:
         info: 'You do not have permission to access the Rancher AI Assistant. Please contact your administrator or refer to our <docsUrl>documentation</docsUrl>'
     assistant:
@@ -179,6 +187,8 @@ ai:
       awaitingConfirmation: 'Awaiting confirmation'
       generatingResponse: 'Generating response'
       processingSubagent: 'Processing Agent'
+      resumingAgent: 'Resuming Agent'
+      refreshingMcpToken: 'Refreshing authentication token'
       processingTools: 'Processing UI tools'
       confirming: 'Confirming'
       finalizing: 'Finalizing results'
@@ -189,11 +199,12 @@ ai:
       connectionClosed: 'Connection closed'
     label:
       default: processing request
+      authenticationRequired: 'Awaiting authentication'
   error:
     chat:
       generic: 'An error occurred initializing the chat'
-    message:
-      processing: 'Error processing messages: '
+    message: 'Error processing message: '
+    authentication: 'Authentication error: '
     websocket:
       generic: WebSocket error occurred. Please check the status of the Rancher AI Agent and ensure you have the necessary permissions to establish a connection to it.
       connection: Failed to connect to Rancher AI Agent.

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -180,6 +180,7 @@ ai:
   processing:
     phase:
       idle: ''
+      setup: 'Preparing chat'
       initializing: 'Initializing'
       thinking: 'Thinking'
       working: 'Working'

--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -389,6 +389,38 @@ aiConfig:
             title: CA Bundle
             label: TLS Secret
             tooltip: 'If your MCP server uses a self-signed certificate, please provide the TLS secret name containing the CA certificate to allow the AI agent to trust the MCP server. The secret must be in the same namespace as the AI agent and contain the `tls.crt` key with a valid CA certificate. If your MCP server uses a certificate signed by a well-known CA, you can leave this field empty.'
+          oauth2:
+            metadata:
+              label: Metadata endpoint
+              placeholder: Enter a valid URL
+              discoverInfo:
+                info: 'Try to <action>automatically discover the metadata endpoint</action> below based on the <b>MCP endpoint</b> URL.'
+                inProgress: 'Metadata endpoint discovery is now in progress... <action>Cancel</action>'
+                success: 'The metadata endpoint was successfully retrieved and filled it automatically. <action>Run it again</action>.'
+                warning: 'Based on the current <b>MCP endpoint</b> URL, the metadata endpoint could not be retrieved automatically.<message></message><br>Please review it and <action>Try again.</action>'
+                message: '<br>{message}<br>'
+            client:
+              discoverInfo:
+                info: 'Try to <action>automatically discover the client registration and the scope details</action> below based on the <b>Metadata endpoint</b> URL.'
+                inProgress: 'Client registration and scope details discovery is now in progress... <action>Cancel</action>'
+                success: 'The client registration and the scope details were successfully retrieved and filled it automatically. <action>Run it again</action>.'
+                warning: 'Based on the current <b>Metadata endpoint</b> URL, the client registration and the scope details could not be retrieved automatically.<message></message><br>Please review it and <action>Try again.</action>'
+                message: '<br>{message}<br>'
+            clientId:
+              label: Client ID
+              placeholder: 'Enter the client ID'
+            clientSecret:
+              label: Client Secret
+              placeholder: 'Enter the client secret'
+            scopes:
+              label: Scopes
+              placeholder:
+                input: 'No scopes discovered, enter them manually separated by whitespace (optional)'
+                select: |-
+                  {count, plural,
+                    =1 { {count} scope available (optional) }
+                    other { {count} scopes to choose from (optional) }
+                  }
           mcpURL:
             label: Endpoint
             placeholder: https://endpoint.mcp
@@ -417,6 +449,7 @@ aiConfig:
               basic: Basic authentication
               rancher: Rancher authentication
               header: Custom Headers authentication
+              oauth2: OAuth2 authentication
       tools:
         header: UI Tools
         description: Configure the UI tools

--- a/pkg/rancher-ai-ui/pages/Chat.vue
+++ b/pkg/rancher-ai-ui/pages/Chat.vue
@@ -146,6 +146,24 @@ const systemErrors = computed(() => {
   }
 });
 
+const processingMessageState = computed(() => {
+  if (!hasPermissions) {
+    return null;
+  }
+
+  // We don't want to show the processing message state when the websocket connection is not open.
+  if (!ws.value || ws.value.readyState !== WebSocket.OPEN) {
+    return null;
+  }
+
+  // Connection phase takes priority over the processing message state.
+  if (connectionPhase.value && connectionPhase.value !== ConnectionPhase.Idle) {
+    return null;
+  }
+
+  return processingState.value;
+});
+
 const disabled = computed(() => {
   return aiAgentDeploymentState.value !== AIServiceState.Active ||
     systemErrors.value.length > 0 ||
@@ -408,7 +426,7 @@ function unmount() {
         :messages="messages"
         :system-errors="systemErrors"
         :disabled="hasPermissions && (systemErrors?.length > 0 || !isChatInitialized || aiAgentDeploymentState !== AIServiceState.Active)"
-        :processing-state="hasPermissions ? processingState : { phase: MessagePhase.Idle }"
+        :processing-state="processingMessageState"
         v-bind="$attrs"
         @update:message="updateMessage"
         @confirm:message="confirmMessage($event, ws)"
@@ -416,6 +434,7 @@ function unmount() {
       />
       <Processing
         class="connection-processing-label text-label"
+        data-test-prefix="connection"
         :phase="connectionPhase"
         :show-progress="![
           ConnectionPhase.Connected,
@@ -424,8 +443,8 @@ function unmount() {
         ].includes(connectionPhase)"
       />
       <Context
-        :value="!hasPermissions || systemErrors.length ? [] : context"
-        :disabled="disabled"
+        :value="hasPermissions ? context : []"
+        :disabled="!isChatInitialized || disabled"
         @select="selectContext"
       />
       <Console
@@ -433,7 +452,7 @@ function unmount() {
         :llm-config="llmConfig"
         :agents="chatAgents"
         :agent-name="agentName"
-        :disabled="disabled"
+        :disabled="!isChatInitialized || disabled"
         :messages="messages"
         :has-permissions="hasPermissions"
         @input:content="ensureConnectionAndSendMessage($event)"

--- a/pkg/rancher-ai-ui/pages/Chat.vue
+++ b/pkg/rancher-ai-ui/pages/Chat.vue
@@ -47,6 +47,7 @@ const {
   agents,
   agentName,
   selectAgent,
+  fetchAgents,
 } = useAgentComposable(CHAT_ID);
 
 const {
@@ -315,6 +316,7 @@ watch(() => aiAgentDeploymentState.value, (newState, oldState) => {
    * AI agent became active on mount or after a service state update - connect to the existing chat if there is one in memory, otherwise start a new one
    */
   if (oldState !== AIServiceState.Active && newState === AIServiceState.Active) {
+    fetchAgents();
     connect(storageType === StorageType.InMemory ? null : chatId);
   }
 

--- a/pkg/rancher-ai-ui/pages/Chat.vue
+++ b/pkg/rancher-ai-ui/pages/Chat.vue
@@ -148,7 +148,7 @@ const systemErrors = computed(() => {
 });
 
 const processingMessageState = computed(() => {
-  if (!hasPermissions) {
+  if (!hasPermissions.value) {
     return null;
   }
 

--- a/pkg/rancher-ai-ui/pages/settings/Settings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/Settings.vue
@@ -129,7 +129,7 @@ async function fetchAiAgentSettings() {
         opt:  { watch: true }
       });
     } catch (err) {
-      warn(`Unable to fetch the ${ AGENT_CONFIG_SECRET_NAME } secret: `, { err });
+      warn(`Unable to fetch the ${ AGENT_CONFIG_SECRET_NAME } secret: `, err);
     }
 
     for (const entry in (secret?.data || {})) {
@@ -145,7 +145,7 @@ async function fetchAiAgentSettings() {
         opt:  { watch: true }
       });
     } catch (err) {
-      warn(`Unable to fetch the ${ AGENT_CONFIG_CONFIG_MAP_NAME } configMap: `, { err });
+      warn(`Unable to fetch the ${ AGENT_CONFIG_CONFIG_MAP_NAME } configMap: `, err);
     }
 
     for (const entry in (configMap?.data || {})) {
@@ -169,7 +169,7 @@ async function fetchAiAgentConfigCRDs() {
         opt:  { watch: true }
       });
     } catch (err) {
-      warn('Unable to fetch AI Agent Config CRDs: ', { err });
+      warn('Unable to fetch AI Agent Config CRDs: ', err);
     }
   }
 
@@ -193,13 +193,13 @@ async function fetchUIToolsConfigSettings() {
         opt:  { watch: true }
       });
     } catch (err) {
-      warn('Unable to fetch UI Tools Config ConfigMap: ', { err });
+      warn('Unable to fetch UI Tools Config ConfigMap: ', err);
     }
 
     try {
       uiToolsConfigSettings = JSON.parse(configMap?.data?.config || '{}');
     } catch (err) {
-      warn('Failed to parse UI Tools Config ConfigMap data:', { err });
+      warn('Failed to parse UI Tools Config ConfigMap data:', err);
     }
   }
 
@@ -251,7 +251,7 @@ async function saveAiAgentConfigCRDs() {
       opt:  { watch: true }
     });
   } catch (err) {
-    warn('Unable to fetch AI Agent Config CRDs: ', { err });
+    warn('Unable to fetch AI Agent Config CRDs: ', err);
   }
 
   const crdsToSave = aiAgentConfigCRDs.value || [];
@@ -264,7 +264,7 @@ async function saveAiAgentConfigCRDs() {
       try {
         await crd.remove();
       } catch (err) {
-        warn(`Unable to delete AI Agent Config CRD ${ crd.metadata.name }: `, { err });
+        warn(`Unable to delete AI Agent Config CRD ${ crd.metadata.name }: `, err);
       }
     }
   }
@@ -303,7 +303,7 @@ async function saveAiAgentConfigCRDs() {
     try {
       await aiAgentConfigCRD.save();
     } catch (err) {
-      warn(`Unable to create AI Agent Config CRD ${ crd.metadata.name }: `, { err });
+      warn(`Unable to create AI Agent Config CRD ${ crd.metadata.name }: `, err);
     }
   }
 
@@ -322,7 +322,7 @@ async function saveUIToolsConfig() {
       id:   `${ AGENT_NAMESPACE }/${ TOOLS_CONFIG_NAME }`,
     });
   } catch (err) {
-    warn('Unable to fetch UI Tools Config ConfigMap: ', { err });
+    warn('Unable to fetch UI Tools Config ConfigMap: ', err);
   }
 
   if (configMap) {
@@ -331,7 +331,7 @@ async function saveUIToolsConfig() {
     try {
       await configMap.save();
     } catch (err) {
-      warn('Unable to save UI Tools Config ConfigMap: ', { err });
+      warn('Unable to save UI Tools Config ConfigMap: ', err);
     }
   } else {
     warn('UI Tools Config ConfigMap not found, cannot save settings');
@@ -394,7 +394,7 @@ async function saveAiAgentConfigAuthenticationSecrets() {
             opt:  { watch: true }
           });
         } catch (err) {
-          warn(`Secret ${ aiAgentConfigCRD?.spec.authenticationSecret } for agent ${ agent } not found, creating a new one: `, { err });
+          warn(`Secret ${ aiAgentConfigCRD?.spec.authenticationSecret } for agent ${ agent } not found, creating a new one: `, err);
         }
 
         if (secret) {
@@ -432,7 +432,7 @@ async function saveAiAgentConfigAuthenticationSecrets() {
       // Update reference to the new secret in the corresponding AI Agent
       aiAgentConfigCRD.spec.authenticationSecret = savedSecret.metadata.name;
     } catch (err) {
-      warn(`Unable to save secret ${ secret.metadata.name } for agent ${ agent }: `, { err });
+      warn(`Unable to save secret ${ secret.metadata.name } for agent ${ agent }: `, err);
     }
   }
 }
@@ -461,7 +461,7 @@ async function cleanupAiAgentConfigAuthenticationSecrets() {
           await secret.remove();
         }
       } catch (err) {
-        warn(`Secret ${ secretName } not found or already deleted: `, { err });
+        warn(`Secret ${ secretName } not found or already deleted: `, err);
       }
     }
   }
@@ -484,7 +484,7 @@ async function redeployAiAgent() {
 
     await deployment.save();
   } catch (err) {
-    warn('Unable to fetch rancher-ai-agent deployment: ', { err });
+    warn('Unable to fetch rancher-ai-agent deployment: ', err);
   }
 }
 

--- a/pkg/rancher-ai-ui/pages/settings/Settings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/Settings.vue
@@ -26,15 +26,16 @@ import Loading from '@shell/components/Loading.vue';
 import RichTranslation from '@shell/components/RichTranslation.vue';
 import AppModal from '@shell/components/AppModal.vue';
 import {
-  SettingsFormData, Settings, Workload, AiAgentConfigSecretPayload, AIAgentConfigAuthType,
+  SettingsFormData, Settings, Workload, AiAgentConfigBasicSecretPayload, AIAgentConfigAuthType,
   SettingsPermissions,
+  AiAgentConfigOAuth2SecretPayload,
 } from './types';
 import { AgentSettings, AIAgentConfigCRD, UIToolsConfigs } from '../../types';
 import { AI_AGENT_LABELS } from '../../labels-annotations';
 import SettingsRow from './SettingsRow.vue';
-import AIAgentConfigs from './sections/AIAgentConfigs.vue';
-import UIToolsConfig from './sections/ui-tools-config/index.vue';
 import AIAgentSettings from './sections/AIAgentSettings.vue';
+import AIAgentConfigs from './sections/ai-agent-configs/index.vue';
+import UIToolsConfig from './sections/ui-tools-config/index.vue';
 import ApplySettings from '../../dialog/ApplySettingsCard.vue';
 import { useAIAgentApiComposable } from '../../composables/useAIAgentApiComposable';
 import { useToolsComposable } from '../../composables/useToolsComposable';
@@ -69,7 +70,7 @@ const aiAgentConfigCRDs = ref<AIAgentConfigCRD[] | null>(null);
 const initAiAgentConfigCRDs = ref<AIAgentConfigCRD[]>([]);
 const uiToolsSettings = ref<UIToolsConfigs | null>(null);
 
-const authenticationSecrets = ref<Record<string, AiAgentConfigSecretPayload | null>>({});
+const authenticationSecrets = ref<Record<string, AiAgentConfigBasicSecretPayload | AiAgentConfigOAuth2SecretPayload | null>>({});
 
 const permissions = ref<SettingsPermissions | null>(null);
 
@@ -289,7 +290,11 @@ async function saveAiAgentConfigCRDs() {
     }
 
     // Normalize authenticationSecret
-    if (aiAgentConfigCRD.spec.authenticationType === AIAgentConfigAuthType.BASIC || aiAgentConfigCRD.spec.authenticationType === AIAgentConfigAuthType.HEADER) {
+    if (
+      aiAgentConfigCRD.spec.authenticationType === AIAgentConfigAuthType.BASIC ||
+      aiAgentConfigCRD.spec.authenticationType === AIAgentConfigAuthType.OAUTH2 ||
+      aiAgentConfigCRD.spec.authenticationType === AIAgentConfigAuthType.HEADER
+    ) {
       aiAgentConfigCRD.spec.authenticationSecret = aiAgentConfigCRD.spec.authenticationSecret?.replaceAll(`${ AGENT_NAMESPACE }/`, '');
     } else {
       delete aiAgentConfigCRD.spec.authenticationSecret;
@@ -341,36 +346,123 @@ async function saveAiAgentConfigAuthenticationSecrets() {
     const aiAgentConfigCRD = aiAgentConfigCRDs.value?.find((c) => c.metadata.name === agent);
     const secretPayload = authenticationSecrets.value[agent];
 
-    if (!aiAgentConfigCRD || !secretPayload || (!secretPayload.privateKey && !secretPayload.publicKey)) {
-      // No secret data to save
+    if (!aiAgentConfigCRD || !secretPayload) {
       continue;
     }
 
-    const data = {
-      password: base64Encode(secretPayload.privateKey || ''),
-      username: base64Encode(secretPayload.publicKey || ''),
-    };
+    let secret;
 
-    const secret = await store.dispatch('management/create', {
-      type:     SECRET,
-      metadata: {
-        namespace:    AGENT_NAMESPACE,
-        generateName: 'ai-agent-auth-',
-        labels:       { [AI_AGENT_LABELS.MANAGED]: 'true' }
-      },
-      data,
-    });
+    switch (aiAgentConfigCRD.spec.authenticationType) {
+    case AIAgentConfigAuthType.BASIC:
+      const payload = secretPayload as AiAgentConfigBasicSecretPayload;
 
-    secret._type = SECRET_TYPES.BASIC;
+      if (payload.privateKey && payload.publicKey) {
+        const data = {
+          password: base64Encode(payload.privateKey || ''),
+          username: base64Encode(payload.publicKey || ''),
+        };
+
+        secret = await store.dispatch('management/create', {
+          type:     SECRET,
+          metadata: {
+            namespace:    AGENT_NAMESPACE,
+            generateName: 'ai-agent-auth-',
+            labels:       { [AI_AGENT_LABELS.MANAGED]: 'true' }
+          },
+          data,
+        });
+
+        secret._type = SECRET_TYPES.BASIC;
+      }
+
+      break;
+    case AIAgentConfigAuthType.OAUTH2:
+      const oauthPayload = secretPayload as AiAgentConfigOAuth2SecretPayload;
+
+      const data = {
+        metadataEndpoint: base64Encode(oauthPayload.metadataEndpoint || ''),
+        clientID:         base64Encode(oauthPayload.clientID || ''),
+        clientSecret:     base64Encode(oauthPayload.clientSecret || ''),
+        scope:            base64Encode((oauthPayload.scopes || []).join(' ')),
+      };
+
+      if (data.metadataEndpoint && data.clientID && data.clientSecret) {
+        try {
+          secret = await store.dispatch(`management/find`, {
+            type: SECRET,
+            id:   `${ AGENT_NAMESPACE }/${ aiAgentConfigCRD?.spec.authenticationSecret }`,
+            opt:  { watch: true }
+          });
+        } catch (err) {
+          warn(`Secret ${ aiAgentConfigCRD?.spec.authenticationSecret } for agent ${ agent } not found, creating a new one: `, { err });
+        }
+
+        if (secret) {
+          secret.data = {
+            ...(secret.data || {}),
+            ...data,
+          };
+        } else {
+          secret = await store.dispatch('management/create', {
+            type:     SECRET,
+            metadata: {
+              namespace:    AGENT_NAMESPACE,
+              generateName: 'ai-agent-auth-',
+              labels:       { [AI_AGENT_LABELS.MANAGED]: 'true' }
+            },
+            data,
+          });
+        }
+
+        secret._type = SECRET_TYPES.OPAQUE;
+      }
+
+      break;
+    default:
+      break;
+    }
+
+    if (!secret) {
+      continue;
+    }
 
     try {
       const savedSecret = await secret.save();
 
-      // Update reference to the new secret in the corresponding AI Agent Config CRD
-      aiAgentConfigCRD.spec.authenticationType = AIAgentConfigAuthType.BASIC;
+      // Update reference to the new secret in the corresponding AI Agent
       aiAgentConfigCRD.spec.authenticationSecret = savedSecret.metadata.name;
     } catch (err) {
       warn(`Unable to save secret ${ secret.metadata.name } for agent ${ agent }: `, { err });
+    }
+  }
+}
+
+/**
+ * Cleans up the AI agent config authentication secrets that are no longer used.
+ */
+async function cleanupAiAgentConfigAuthenticationSecrets() {
+  // As of now, we only clean up OAUTH2 secrets
+  const existingOauth2Secrets = initAiAgentConfigCRDs.value
+    .filter((crd) => !!crd.spec.authenticationSecret && crd.spec.authenticationType === AIAgentConfigAuthType.OAUTH2)
+    .map((crd) => crd.spec.authenticationSecret);
+
+  for (const secretName of existingOauth2Secrets) {
+    const existsInForm = aiAgentConfigCRDs.value?.find((c) => c.spec.authenticationSecret === secretName);
+
+    if (!existsInForm) {
+      try {
+        const secret = await store.dispatch(`management/find`, {
+          type: SECRET,
+          id:   `${ AGENT_NAMESPACE }/${ secretName }`,
+          opt:  { watch: true }
+        });
+
+        if (secret) {
+          await secret.remove();
+        }
+      } catch (error) {
+        warn(`Secret ${ secretName } not found or already deleted: `, { error });
+      }
     }
   }
 }
@@ -410,6 +502,9 @@ const save = async(btnCB: (arg: boolean) => void) => { // eslint-disable-line no
       if (permissions?.value?.create.canCreateAiAgentCRDS) {
         // Save AI Agent Config authentication secrets created for the agents
         await saveAiAgentConfigAuthenticationSecrets();
+
+        // Clean up authentication secrets for agents that have been removed from the form or have changed their authentication type
+        await cleanupAiAgentConfigAuthenticationSecrets();
 
         // Save AI Agent Config CRDs
         await saveAiAgentConfigCRDs();

--- a/pkg/rancher-ai-ui/pages/settings/Settings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/Settings.vue
@@ -95,8 +95,8 @@ async function fetchAiAgentDeployment() {
         type:    WORKLOAD_TYPES.DEPLOYMENT,
         id:      `${ AGENT_NAMESPACE }/${ AGENT_NAME }`
       });
-    } catch (e) {
-      warn('Error fetching AI agent deployment:', e);
+    } catch (err) {
+      warn('Error fetching AI agent deployment:', err);
     }
   }
 }
@@ -107,8 +107,8 @@ async function fetchAiAgentDeployment() {
 async function fetchChatSettings() {
   try {
     chatSettings.value = await fetchSettings();
-  } catch (e) {
-    warn('Error fetching chat settings: ', e);
+  } catch (err) {
+    warn('Error fetching chat settings: ', err);
   }
 }
 
@@ -198,8 +198,8 @@ async function fetchUIToolsConfigSettings() {
 
     try {
       uiToolsConfigSettings = JSON.parse(configMap?.data?.config || '{}');
-    } catch (error) {
-      warn('Failed to parse UI Tools Config ConfigMap data:', { error });
+    } catch (err) {
+      warn('Failed to parse UI Tools Config ConfigMap data:', { err });
     }
   }
 
@@ -460,8 +460,8 @@ async function cleanupAiAgentConfigAuthenticationSecrets() {
         if (secret) {
           await secret.remove();
         }
-      } catch (error) {
-        warn(`Secret ${ secretName } not found or already deleted: `, { error });
+      } catch (err) {
+        warn(`Secret ${ secretName } not found or already deleted: `, { err });
       }
     }
   }
@@ -520,8 +520,8 @@ const save = async(btnCB: (arg: boolean) => void) => { // eslint-disable-line no
 
     apiError.value = '';
     btnCB(true);
-  } catch (error) {
-    apiError.value = t('aiConfig.form.save.apiError', { error }, true);
+  } catch (err) {
+    apiError.value = t('aiConfig.form.save.apiError', { error: err }, true);
     btnCB(false);
   }
 

--- a/pkg/rancher-ai-ui/pages/settings/__tests__/Settings.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/__tests__/Settings.test.ts
@@ -6,6 +6,11 @@ import { AGENT_NAMESPACE, AGENT_CONFIG_SECRET_NAME, AGENT_NAME } from '../../../
 import { Settings as SettingsEnum, AIAgentConfigAuthType } from '../types';
 import { AIAgentConfigCRD } from '../../../types';
 
+const SECRET_TYPES = {
+  OPAQUE:            'Opaque',
+  BASIC:             'kubernetes.io/basic-auth',
+};
+
 // Mock components with external dependencies
 jest.mock('../../../composables/useAIAgentApiComposable', () => ({
   useAIAgentApiComposable: jest.fn(() => ({
@@ -14,6 +19,7 @@ jest.mock('../../../composables/useAIAgentApiComposable', () => ({
   }))
 }));
 jest.mock('../sections/AIAgentSettings.vue', () => ({}));
+jest.mock('../sections/ai-agent-configs/index.vue', () => ({}));
 jest.mock('../../../dialog/ApplySettingsCard.vue', () => ({}));
 jest.mock('@components/RcButton/RcButton.vue', () => ({
   default: {
@@ -1331,6 +1337,645 @@ describe('Settings.vue', () => {
 
       // Null resourceMethods should not crash and default to no create permission
       expect(vm.permissions?.create.canCreateSecrets).toBe(false);
+    });
+  });
+
+  describe('Authentication Secrets Management', () => {
+    describe('saveAiAgentConfigAuthenticationSecrets', () => {
+      it('should save BASIC auth secret successfully', async() => {
+        const mockSecret = {
+          metadata: {
+            namespace:    AGENT_NAMESPACE,
+            generateName: 'ai-agent-auth-',
+            name:         'ai-agent-auth-abc123'
+          },
+          _type: SECRET_TYPES.BASIC,
+          save:  jest.fn().mockResolvedValue({ metadata: { name: 'ai-agent-auth-abc123' } })
+        };
+
+        const dispatch = jest.fn((action: string) => {
+          if (action === 'management/create') {
+            return Promise.resolve(mockSecret);
+          }
+          if (action === 'management/find') {
+            return Promise.resolve(mockSecret);
+          }
+          if (action === 'management/findAll') {
+            return Promise.resolve([]);
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const basicCRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'test-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType: AIAgentConfigAuthType.BASIC
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.aiAgentConfigCRDs = [basicCRD];
+        vm.authenticationSecrets = {
+          'test-agent': {
+            selected:   '_basic',
+            privateKey: 'test-password',
+            publicKey:  'test-username'
+          }
+        };
+
+        await vm.saveAiAgentConfigAuthenticationSecrets();
+
+        expect(dispatch).toHaveBeenCalledWith('management/create', expect.objectContaining({ type: SECRET }));
+        expect(mockSecret.save).toHaveBeenCalled();
+      });
+
+      it('should save OAUTH2 auth secret (new secret)', async() => {
+        const mockSecret = {
+          metadata: {
+            namespace:    AGENT_NAMESPACE,
+            generateName: 'ai-agent-auth-',
+            name:         'ai-agent-auth-oauth-123'
+          },
+          _type: SECRET_TYPES.OPAQUE,
+          save:  jest.fn().mockResolvedValue({ metadata: { name: 'ai-agent-auth-oauth-123' } })
+        };
+
+        const dispatch = jest.fn((action: string) => {
+          if (action === 'management/create') {
+            return Promise.resolve(mockSecret);
+          }
+          if (action === 'management/find') {
+            return Promise.reject(new Error('Secret not found'));
+          }
+          if (action === 'management/findAll') {
+            return Promise.resolve([]);
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const oauth2CRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'oauth-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType: AIAgentConfigAuthType.OAUTH2
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.aiAgentConfigCRDs = [oauth2CRD];
+        vm.authenticationSecrets = {
+          'oauth-agent': {
+            metadataEndpoint: 'https://oauth.example.com/.well-known/openid-configuration',
+            clientID:         'test-client-id',
+            clientSecret:     'test-client-secret',
+            scopes:           ['openid', 'profile']
+          }
+        };
+
+        await vm.saveAiAgentConfigAuthenticationSecrets();
+
+        expect(dispatch).toHaveBeenCalledWith('management/create', expect.objectContaining({ type: SECRET }));
+        expect(mockSecret.save).toHaveBeenCalled();
+      });
+
+      it('should update existing OAUTH2 auth secret', async() => {
+        const existingSecret = {
+          metadata: {
+            name:      'existing-oauth-secret',
+            namespace: AGENT_NAMESPACE
+          },
+          data:     { metadataEndpoint: 'old-endpoint' },
+          _type:    SECRET_TYPES.OPAQUE,
+          save:     jest.fn().mockResolvedValue({ metadata: { name: 'existing-oauth-secret' } })
+        };
+
+        const dispatch = jest.fn((action: string) => {
+          if (action === 'management/find') {
+            return Promise.resolve(existingSecret);
+          }
+          if (action === 'management/findAll') {
+            return Promise.resolve([]);
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const oauth2CRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'oauth-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType:   AIAgentConfigAuthType.OAUTH2,
+            authenticationSecret: 'existing-oauth-secret'
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.aiAgentConfigCRDs = [oauth2CRD];
+        vm.authenticationSecrets = {
+          'oauth-agent': {
+            metadataEndpoint: 'https://oauth.example.com/.well-known/openid-configuration',
+            clientID:         'new-client-id',
+            clientSecret:     'new-client-secret',
+            scopes:           ['openid']
+          }
+        };
+
+        await vm.saveAiAgentConfigAuthenticationSecrets();
+
+        expect(existingSecret.save).toHaveBeenCalled();
+      });
+
+      it('should skip saving when CRD is not found', async() => {
+        const dispatch = jest.fn((action: string) => {
+          if (action === 'management/find') {
+            return Promise.resolve(mockSecret());
+          }
+          if (action === 'management/findAll') {
+            return Promise.resolve([]);
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.aiAgentConfigCRDs = []; // Empty CRDs
+        vm.authenticationSecrets = {
+          'non-existent-agent': {
+            privateKey: 'test-password',
+            publicKey:  'test-username'
+          }
+        };
+
+        await vm.saveAiAgentConfigAuthenticationSecrets();
+
+        // Should not call create dispatch since CRD doesn't exist
+        expect(dispatch).not.toHaveBeenCalledWith('management/create', expect.objectContaining({ type: SECRET }));
+      });
+
+      it('should skip saving when payload is null', async() => {
+        const dispatch = jest.fn((action: string) => {
+          if (action === 'management/find') {
+            return Promise.resolve(mockSecret());
+          }
+          if (action === 'management/findAll') {
+            return Promise.resolve([]);
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const basicCRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'test-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType: AIAgentConfigAuthType.BASIC
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.aiAgentConfigCRDs = [basicCRD];
+        vm.authenticationSecrets = { 'test-agent': null };
+
+        await vm.saveAiAgentConfigAuthenticationSecrets();
+
+        expect(dispatch).not.toHaveBeenCalledWith('management/create', expect.objectContaining({ type: SECRET }));
+      });
+
+      it('should skip BASIC auth when privateKey or publicKey is missing', async() => {
+        const dispatch = jest.fn();
+
+        const basicCRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'test-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType: AIAgentConfigAuthType.BASIC
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.aiAgentConfigCRDs = [basicCRD];
+        vm.authenticationSecrets = {
+          'test-agent': {
+            selected:   '_basic',
+            privateKey: '', // Missing privateKey
+            publicKey:  'test-username'
+          }
+        };
+
+        await vm.saveAiAgentConfigAuthenticationSecrets();
+
+        expect(dispatch).not.toHaveBeenCalledWith('management/create', expect.objectContaining({ type: SECRET }));
+      });
+
+      it('should skip OAUTH2 auth when any required field is missing', async() => {
+        const dispatch = jest.fn();
+
+        const oauth2CRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'oauth-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType: AIAgentConfigAuthType.OAUTH2
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.aiAgentConfigCRDs = [oauth2CRD];
+        vm.authenticationSecrets = {
+          'oauth-agent': {
+            metadataEndpoint: 'https://oauth.example.com/.well-known/openid-configuration',
+            clientID:         '', // Missing clientID
+            clientSecret:     'test-client-secret',
+            scopes:           ['openid']
+          }
+        };
+
+        await vm.saveAiAgentConfigAuthenticationSecrets();
+
+        expect(dispatch).not.toHaveBeenCalledWith('management/create', expect.objectContaining({ type: SECRET }));
+      });
+
+      it('should handle error during secret save gracefully', async() => {
+        const mockSecret = {
+          metadata: { name: 'ai-agent-auth-error' },
+          _type:    SECRET_TYPES.BASIC,
+          save:     jest.fn().mockRejectedValue(new Error('Save failed'))
+        };
+
+        const dispatch = jest.fn((action: string) => {
+          if (action === 'management/create') {
+            return Promise.resolve(mockSecret);
+          }
+          if (action === 'management/find') {
+            return Promise.resolve(mockSecret);
+          }
+          if (action === 'management/findAll') {
+            return Promise.resolve([]);
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const basicCRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'test-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType: AIAgentConfigAuthType.BASIC
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.aiAgentConfigCRDs = [basicCRD];
+        vm.authenticationSecrets = {
+          'test-agent': {
+            privateKey: 'test-password',
+            publicKey:  'test-username'
+          }
+        };
+
+        // Should not throw, but warn should be called
+        await expect(vm.saveAiAgentConfigAuthenticationSecrets()).resolves.not.toThrow();
+      });
+
+      it('should update CRD authenticationSecret reference after save', async() => {
+        const mockSecret = {
+          metadata: { name: 'saved-secret-name' },
+          _type:    SECRET_TYPES.BASIC,
+          save:     jest.fn().mockResolvedValue({ metadata: { name: 'saved-secret-name' } })
+        };
+
+        const dispatch = jest.fn((action: string) => {
+          if (action === 'management/create') {
+            return Promise.resolve(mockSecret);
+          }
+          if (action === 'management/find') {
+            return Promise.resolve(mockSecret);
+          }
+          if (action === 'management/findAll') {
+            return Promise.resolve([]);
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const basicCRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'test-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType: AIAgentConfigAuthType.BASIC
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.aiAgentConfigCRDs = [basicCRD];
+        vm.authenticationSecrets = {
+          'test-agent': {
+            privateKey: 'test-password',
+            publicKey:  'test-username'
+          }
+        };
+
+        await vm.saveAiAgentConfigAuthenticationSecrets();
+
+        expect(basicCRD.spec.authenticationSecret).toBe('saved-secret-name');
+      });
+    });
+
+    describe('cleanupAiAgentConfigAuthenticationSecrets', () => {
+      it('should remove unused OAUTH2 secrets', async() => {
+        const mockSecret = {
+          metadata: {
+            name:      'unused-oauth-secret',
+            namespace: AGENT_NAMESPACE
+          },
+          remove: jest.fn().mockResolvedValue({})
+        };
+
+        const dispatch = jest.fn((action: string, params?: any) => {
+          if (action === 'management/find' && params?.id?.includes(AGENT_NAME)) {
+            return Promise.resolve({
+              type: 'apps.deployment',
+              spec: { template: { metadata: { annotations: {} } } },
+              save: jest.fn().mockResolvedValue({})
+            });
+          }
+          if (action === 'management/find' && params?.id?.includes('unused-oauth-secret')) {
+            return Promise.resolve(mockSecret);
+          }
+          if (action === 'management/find') {
+            return Promise.resolve(mockSecret);
+          }
+          if (action === 'management/findAll') {
+            return Promise.resolve([]);
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const oauth2CRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'oauth-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType:   AIAgentConfigAuthType.OAUTH2,
+            authenticationSecret: 'unused-oauth-secret'
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        await flushPromises();
+
+        // Set initial CRDs with the oauth secret
+        vm.initAiAgentConfigCRDs = [oauth2CRD];
+        // Current CRDs no longer have this agent (secret is unused)
+        vm.aiAgentConfigCRDs = [];
+
+        await vm.cleanupAiAgentConfigAuthenticationSecrets();
+
+        expect(dispatch).toHaveBeenCalledWith(
+          'management/find',
+          expect.objectContaining({
+            type: SECRET,
+            id:   `${ AGENT_NAMESPACE }/unused-oauth-secret`
+          })
+        );
+        expect(mockSecret.remove).toHaveBeenCalled();
+      });
+
+      it('should not remove OAUTH2 secrets that are still in use', async() => {
+        const dispatch = jest.fn();
+
+        const oauth2CRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'oauth-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType:   AIAgentConfigAuthType.OAUTH2,
+            authenticationSecret: 'in-use-oauth-secret'
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.initAiAgentConfigCRDs = [oauth2CRD];
+        // Same secret is still in current CRDs
+        vm.aiAgentConfigCRDs = [oauth2CRD];
+
+        await vm.cleanupAiAgentConfigAuthenticationSecrets();
+
+        // Should not try to remove the secret
+        expect(dispatch).not.toHaveBeenCalledWith(
+          'management/find',
+          expect.objectContaining({ type: SECRET })
+        );
+      });
+
+      it('should handle error when secret not found gracefully', async() => {
+        const dispatch = jest.fn((action: string) => {
+          if (action === 'management/find') {
+            return Promise.reject(new Error('Secret not found'));
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const oauth2CRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'oauth-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType:   AIAgentConfigAuthType.OAUTH2,
+            authenticationSecret: 'missing-oauth-secret'
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.initAiAgentConfigCRDs = [oauth2CRD];
+        vm.aiAgentConfigCRDs = [];
+
+        // Should not throw, but warn should be called
+        await expect(vm.cleanupAiAgentConfigAuthenticationSecrets()).resolves.not.toThrow();
+      });
+
+      it('should not clean up BASIC auth secrets (only OAUTH2)', async() => {
+        const dispatch = jest.fn();
+
+        const basicCRD = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'basic-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType:   AIAgentConfigAuthType.BASIC,
+            authenticationSecret: 'basic-secret'
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.initAiAgentConfigCRDs = [basicCRD];
+        vm.aiAgentConfigCRDs = [];
+
+        await vm.cleanupAiAgentConfigAuthenticationSecrets();
+
+        // Should not try to remove BASIC auth secrets
+        expect(dispatch).not.toHaveBeenCalledWith(
+          'management/find',
+          expect.objectContaining({ type: SECRET })
+        );
+      });
+
+      it('should not clean up secrets without authenticationSecret field', async() => {
+        const dispatch = jest.fn();
+
+        const crdWithoutSecret = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'no-secret-agent',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType:   AIAgentConfigAuthType.OAUTH2,
+            authenticationSecret: '' // Empty secret
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.initAiAgentConfigCRDs = [crdWithoutSecret];
+        vm.aiAgentConfigCRDs = [];
+
+        await vm.cleanupAiAgentConfigAuthenticationSecrets();
+
+        // Should not try to remove since authenticationSecret is empty
+        expect(dispatch).not.toHaveBeenCalledWith(
+          'management/find',
+          expect.objectContaining({ type: SECRET })
+        );
+      });
+
+      it('should handle multiple OAUTH2 secrets cleanup', async() => {
+        const mockSecret1 = {
+          metadata: {
+            name:      'unused-oauth-secret-1',
+            namespace: AGENT_NAMESPACE
+          },
+          remove: jest.fn().mockResolvedValue({})
+        };
+
+        const mockSecret2 = {
+          metadata: {
+            name:      'unused-oauth-secret-2',
+            namespace: AGENT_NAMESPACE
+          },
+          remove: jest.fn().mockResolvedValue({})
+        };
+
+        const dispatch = jest.fn((action: string, params?: any) => {
+          if (action === 'management/find') {
+            if (params?.id?.includes('unused-oauth-secret-1')) {
+              return Promise.resolve(mockSecret1);
+            } else if (params?.id?.includes('unused-oauth-secret-2')) {
+              return Promise.resolve(mockSecret2);
+            }
+          }
+
+          return Promise.resolve(null);
+        });
+
+        const oauth2CRD1 = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'oauth-agent-1',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType:   AIAgentConfigAuthType.OAUTH2,
+            authenticationSecret: 'unused-oauth-secret-1'
+          }
+        });
+
+        const oauth2CRD2 = mockAiAgentConfigCRD({
+          metadata: {
+            name:      'oauth-agent-2',
+            namespace: AGENT_NAMESPACE
+          },
+          spec:     {
+            ...mockAiAgentConfigCRD().spec,
+            authenticationType:   AIAgentConfigAuthType.OAUTH2,
+            authenticationSecret: 'unused-oauth-secret-2'
+          }
+        });
+
+        const wrapper = shallowMount(Settings, initSettings({ dispatch }));
+        const vm = wrapper.vm as any;
+
+        vm.initAiAgentConfigCRDs = [oauth2CRD1, oauth2CRD2];
+        vm.aiAgentConfigCRDs = [];
+
+        await vm.cleanupAiAgentConfigAuthenticationSecrets();
+
+        expect(mockSecret1.remove).toHaveBeenCalled();
+        expect(mockSecret2.remove).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/pkg/rancher-ai-ui/pages/settings/sections/AIAgentSettings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/AIAgentSettings.vue
@@ -521,8 +521,7 @@ onMounted(() => {
       <Password
         :value="formData[chatbotConfigKey]"
         :label="t(`aiConfig.form.${ chatbotConfigKey }.label`)"
-        :disabled="readOnly"
-        :mode="_EDIT"
+        :mode="readOnly ? _VIEW : _EDIT"
         :required="true"
         data-testid="rancher-ai-ui-settings-llm-api-key-input"
         @update:value="(val: string) => updateValue(chatbotConfigKey, val)"

--- a/pkg/rancher-ai-ui/pages/settings/sections/AIAgentSettings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/AIAgentSettings.vue
@@ -216,6 +216,12 @@ const chatbotConfigKey = computed<ChatBotConfigKey>(() => {
   }
 });
 
+const showBasicConfigKey = computed(() => {
+  return formData.value[Settings.ACTIVE_CHATBOT] !== ChatBotEnum.Local &&
+    formData.value[Settings.ACTIVE_CHATBOT] !== ChatBotEnum.Bedrock &&
+    formData.value[Settings.ACTIVE_CHATBOT] !== ChatBotEnum.GenericOpenAI;
+});
+
 /**
  * Validates the AI agent settings
  */
@@ -515,7 +521,7 @@ onMounted(() => {
     </div>
 
     <div
-      v-if="!props.readOnly && formData[Settings.ACTIVE_CHATBOT] !== ChatBotEnum.Local && formData[Settings.ACTIVE_CHATBOT] !== ChatBotEnum.Bedrock && formData[Settings.ACTIVE_CHATBOT] !== ChatBotEnum.GenericOpenAI"
+      v-if="!props.readOnly && showBasicConfigKey"
       class="form-field"
     >
       <Password
@@ -666,7 +672,7 @@ onMounted(() => {
           @update:value="(val: string) => updateValue(Settings.OPENAI_THIRD_PARTY_URL, val)"
         />
         <label class="text-label">
-          {{ t(`aiConfig.form.${ Settings.OPENAI_THIRD_PARTY_URL }.description`) }}
+          {{ t(`aiConfig.form.${ Settings.OPENAI_THIRD_PARTY_URL }.description`, {}, true) }}
         </label>
       </div>
 

--- a/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
@@ -35,6 +35,15 @@ jest.mock('@shell/components/form/Password.vue', () => ({
   }
 }));
 
+// Mock CopyToClipboard component
+jest.mock('@shell/components/CopyToClipboard.vue', () => ({
+  default: {
+    name:     'CopyToClipboard',
+    props:    ['text', 'labelAs', 'class', 'actionColor'],
+    template: '<div />'
+  }
+}));
+
 const DEFAULT_AI_AGENT = 'rancher';
 
 const mockAgent = (overrides = {}): AIAgentConfigCRD => ({

--- a/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
@@ -35,11 +35,11 @@ jest.mock('@shell/components/form/Password.vue', () => ({
   }
 }));
 
-// Mock CopyToClipboard component
-jest.mock('@shell/components/CopyToClipboard.vue', () => ({
+// Mock DetailText component
+jest.mock('@shell/components/DetailText.vue', () => ({
   default: {
-    name:     'CopyToClipboard',
-    props:    ['text', 'labelAs', 'class', 'actionColor'],
+    name:     'DetailText',
+    props:    ['value', 'label-key', 'class'],
     template: '<div />'
   }
 }));

--- a/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
-import AIAgentConfigs from '../AIAgentConfigs.vue';
+import AIAgentConfigs from '../ai-agent-configs/index.vue';
 import { AIAgentConfigCRD } from '../../../../types';
 import { AIAgentConfigAuthType } from '../../types';
 
@@ -22,7 +22,16 @@ jest.mock('@shell/components/form/FileSelector.vue', () => ({
     name:     'FileSelector',
     template: '<div />',
     props:    ['value', 'label', 'required'],
-    emits:    ['update:value']
+    emits:    ['update:value'],
+  }
+}));
+
+// Mock Password component to avoid clipboard-polyfill dependency
+jest.mock('@shell/components/form/Password.vue', () => ({
+  default: {
+    name:     'Password',
+    props:    ['value', 'label', 'mode', 'disabled'],
+    template: '<div />'
   }
 }));
 
@@ -742,6 +751,40 @@ describe('AIAgentConfigs.vue', () => {
       expect(vm.agentSecrets['test-agent']).toEqual(secretPayload);
     });
 
+    it('should store new secret in agentSecrets when OAUTH2 is selected', () => {
+      const wrapper = shallowMount(AIAgentConfigs, {
+        ...requiredSetup(),
+        props: { value: [mockAgent()] }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.updateAgent({
+        spec: {
+          ...vm.selectedAgent.spec,
+          authenticationType:   AIAgentConfigAuthType.OAUTH2,
+          authenticationSecret: 'test-secret'
+        }
+      });
+
+      const oauth2Payload = {
+        metadataEnpoint: 'http://metadata',
+        scopes:          ['test-scope'],
+        clientId:        'client-id',
+        clientSecret:    'client-secret'
+      };
+
+      vm.updateOauth2AuthSecret(vm.selectedAgent, oauth2Payload);
+
+      // Verify the secret is stored in agentSecrets
+      expect(vm.agentSecrets['test-agent']).toEqual(oauth2Payload);
+
+      // Verify the emission happened with the secrets
+      const emittedSecrets = wrapper.emitted('update:authentication-secrets');
+
+      expect((emittedSecrets as any)?.[(emittedSecrets?.length || 0) - 1]?.[0]['test-agent']).toEqual(oauth2Payload);
+    });
+
     it('should use selected secret directly when existing secret selected', () => {
       const wrapper = shallowMount(AIAgentConfigs, {
         ...requiredSetup(),
@@ -963,7 +1006,7 @@ describe('AIAgentConfigs.vue', () => {
       const vm = wrapper.vm as any;
 
       // Valid agent should not have errors
-      expect(vm.validationErrors['test-agent']).toBeUndefined();
+      expect(vm.validationErrors['test-agent']).toBe(false);
 
       // Create a new agent without mcpURL
       const invalidAgent = mockAgent({
@@ -1003,7 +1046,7 @@ describe('AIAgentConfigs.vue', () => {
 
       const vm = wrapper.vm as any;
 
-      expect(vm.validationErrors['test-agent']).toBeUndefined();
+      expect(vm.validationErrors['test-agent']).toBe(false);
     });
 
     it('should compute validation errors for empty description', () => {
@@ -1086,7 +1129,7 @@ describe('AIAgentConfigs.vue', () => {
 
       const vm = wrapper.vm as any;
 
-      expect(vm.validationErrors['test-agent']).toBeUndefined();
+      expect(vm.validationErrors['test-agent']).toBe(false);
     });
   });
 
@@ -1848,6 +1891,28 @@ describe('AIAgentConfigs.vue', () => {
         expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
       });
 
+      it('should change auth type to OAUTH2', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.RANCHER
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        vm.updateAuthType(AIAgentConfigAuthType.OAUTH2);
+
+        const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.OAUTH2);
+      });
+
       it('should clear authenticationSecret when changing from RANCHER to HEADER', () => {
         const agent = mockAgent({
           spec: {
@@ -1894,6 +1959,31 @@ describe('AIAgentConfigs.vue', () => {
         const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
 
         expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.HEADER);
+        expect(emitted[0].spec.authenticationSecret).toBeUndefined();
+      });
+
+      it('should clear authenticationSecret when changing from HEADER to OAUTH2', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType:   AIAgentConfigAuthType.HEADER,
+            authenticationSecret: 'header-secret'
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // Update to OAUTH2 type
+        vm.updateAuthType(AIAgentConfigAuthType.OAUTH2);
+
+        const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.OAUTH2);
         expect(emitted[0].spec.authenticationSecret).toBeUndefined();
       });
 
@@ -2035,6 +2125,26 @@ describe('AIAgentConfigs.vue', () => {
           spec: {
             ...mockAgent().spec,
             authenticationType: AIAgentConfigAuthType.HEADER
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const selectOrCreate = wrapper.findComponent({ name: 'SelectOrCreateAuthSecret' });
+
+        expect(selectOrCreate.exists()).toBe(false);
+      });
+
+      it('should not render SelectOrCreateAuthSecret when OAUTH2 auth is selected', async() => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.OAUTH2
           }
         });
 
@@ -2215,6 +2325,196 @@ describe('AIAgentConfigs.vue', () => {
         expect(emitted[0].spec.description).toBe('Important Description');
         expect(emitted[0].spec.systemPrompt).toBe('Important Prompt');
         expect(emitted[0].spec.humanValidationTools).toEqual(['tool1', 'tool2']);
+      });
+    });
+
+    describe('OAUTH2 Auth Type', () => {
+      it('should change auth type to OAUTH2', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.RANCHER
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        vm.updateAuthType(AIAgentConfigAuthType.OAUTH2);
+
+        const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.OAUTH2);
+      });
+
+      it('should store OAUTH2 secret payload in agentSecrets', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.OAUTH2
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        const oauth2Payload = {
+          metadataEndpoint: 'https://oauth.example.com/.well-known/openid-configuration',
+          clientID:         'client-id-123',
+          clientSecret:     'client-secret-456',
+          scopes:           ['openid', 'profile', 'email']
+        };
+
+        vm.updateOauth2AuthSecret(vm.selectedAgent, oauth2Payload);
+
+        expect(vm.agentSecrets['test-agent']).toEqual(oauth2Payload);
+      });
+
+      it('should clear authenticationSecret when changing from OAUTH2 to RANCHER', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType:   AIAgentConfigAuthType.OAUTH2,
+            authenticationSecret: 'oauth2-secret'
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        vm.updateAuthType(AIAgentConfigAuthType.RANCHER);
+
+        const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+        expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.RANCHER);
+        expect(emitted[0].spec.authenticationSecret).toBeUndefined();
+      });
+
+      it('should emit update:authentication-secrets when OAUTH2 secret is updated', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.OAUTH2
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        const oauth2Payload = {
+          metadataEndpoint: 'https://oauth.example.com/.well-known/openid-configuration',
+          clientID:         'client-id-123',
+          clientSecret:     'client-secret-456',
+          scopes:           ['openid', 'profile']
+        };
+
+        vm.updateOauth2AuthSecret(oauth2Payload);
+
+        const emitted = wrapper.emitted('update:authentication-secrets');
+
+        expect(emitted).toBeTruthy();
+        expect(emitted![0][0]).toEqual(vm.agentSecrets);
+      });
+
+      it('should handle multiple agents with independent OAUTH2 secrets', async() => {
+        const agent1 = mockAgent({
+          metadata: {
+            name:      'agent-1',
+            namespace: 'ai-agent'
+          },
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.OAUTH2
+          }
+        });
+
+        const agent2 = mockAgent({
+          metadata: {
+            name:      'agent-2',
+            namespace: 'ai-agent'
+          },
+          spec: {
+            ...mockAgent().spec,
+            authenticationType: AIAgentConfigAuthType.OAUTH2
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent1, agent2] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        // Set OAUTH2 secret for agent-1
+        vm.updateOauth2AuthSecret(agent1, {
+          metadataEndpoint: 'https://oauth1.example.com/.well-known/openid-configuration',
+          clientID:         'client-1',
+          clientSecret:     'secret-1',
+          scopes:           ['openid']
+        });
+
+        // Set OAUTH2 secret for agent-2
+        vm.updateOauth2AuthSecret(agent2, {
+          metadataEndpoint: 'https://oauth2.example.com/.well-known/openid-configuration',
+          clientID:         'client-2',
+          clientSecret:     'secret-2',
+          scopes:           ['openid', 'profile']
+        });
+
+        expect(vm.agentSecrets['agent-1'].clientID).toEqual('client-1');
+        expect(vm.agentSecrets['agent-2'].clientID).toEqual('client-2');
+        expect(vm.agentSecrets['agent-1'].scopes).toEqual(['openid']);
+        expect(vm.agentSecrets['agent-2'].scopes).toEqual(['openid', 'profile']);
+      });
+
+      it('should not affect other agent properties when updating OAUTH2 secret', () => {
+        const agent = mockAgent({
+          spec: {
+            ...mockAgent().spec,
+            displayName:          'Important Agent',
+            description:          'Important Description',
+            systemPrompt:         'Important Prompt',
+            humanValidationTools: ['tool1', 'tool2'],
+            authenticationType:   AIAgentConfigAuthType.OAUTH2
+          }
+        });
+
+        const wrapper = shallowMount(AIAgentConfigs, {
+          ...requiredSetup(),
+          props: { value: [agent] }
+        });
+
+        const vm = wrapper.vm as any;
+
+        vm.updateOauth2AuthSecret({
+          metadataEndpoint: 'https://oauth.example.com/.well-known/openid-configuration',
+          clientID:         'client-id',
+          clientSecret:     'client-secret',
+          scopes:           ['openid']
+        });
+
+        // Verify other properties remain unchanged via emitted events if available
+        expect(vm.selectedAgent.spec.displayName).toBe('Important Agent');
+        expect(vm.selectedAgent.spec.description).toBe('Important Description');
+        expect(vm.selectedAgent.spec.systemPrompt).toBe('Important Prompt');
+        expect(vm.selectedAgent.spec.humanValidationTools).toEqual(['tool1', 'tool2']);
       });
     });
   });

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/Oauth2SecretForm.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/Oauth2SecretForm.vue
@@ -8,9 +8,10 @@ import { _EDIT, _VIEW } from '@shell/config/query-params';
 import Password from '@shell/components/form/Password.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+import CopyToClipboard from '@shell/components/CopyToClipboard.vue';
 import formRulesGenerator from '@shell/utils/validators/formRules';
 import { warn } from '../../../../utils/log';
-import { AGENT_NAMESPACE } from '../../../../product';
+import { AGENT_NAME, AGENT_NAMESPACE, AGENT_REST_API_PATH } from '../../../../product';
 import { AIAgentAPIEvent } from '../../../../types';
 import { AiAgentConfigOAuth2SecretPayload } from '../../types';
 import DiscoveryBanner from '../../../../components/DiscoveryBanner/DiscoveryBanner.vue';
@@ -20,6 +21,9 @@ interface DiscoveryStatus {
   result?: 'success' | 'warning' | 'info' | null;
   message?: string;
 }
+
+const HOME_PAGE_URL = window.location.origin;
+const CALLBACK_URL = `${ window.location.origin }/api/v1/namespaces/${ AGENT_NAMESPACE }/services/http:${ AGENT_NAME }:80/proxy/${ AGENT_REST_API_PATH }/oauth2/callback`;
 
 const store = useStore();
 const { t } = useI18n(store);
@@ -302,9 +306,100 @@ onBeforeUnmount(() => {
       />
     </div>
   </div>
+
+  <div class="helper-box">
+    <h4>
+      {{ t('aiConfig.form.section.aiAgent.fields.oauth2.helper.title') }}
+      <i
+        v-clean-tooltip="t('aiConfig.form.section.aiAgent.fields.oauth2.helper.tooltip')"
+        class="icon icon-info tooltip-icon subrow-title-icon"
+      />
+    </h4>
+    <div class="row">
+      <div class="col span-6">
+        <div class="helper-field">
+          <label class="field-label">
+            {{ t('aiConfig.form.section.aiAgent.fields.oauth2.homepageUrl.label') }}
+          </label>
+          <div class="copy-field">
+            <input
+              class="field-value"
+              :value="HOME_PAGE_URL"
+              readonly
+            />
+            <CopyToClipboard
+              :text="HOME_PAGE_URL"
+              label-as="tooltip"
+              class="icon-btn"
+              action-color="bg-transparent"
+            />
+          </div>
+        </div>
+      </div>
+      <div class="col span-6">
+        <div class="helper-field">
+          <label class="field-label">
+            {{ t('aiConfig.form.section.aiAgent.fields.oauth2.callbackUrl.label') }}
+          </label>
+          <div class="copy-field">
+            <input
+              class="field-value"
+              :value="CALLBACK_URL"
+              readonly
+            />
+            <CopyToClipboard
+              :text="CALLBACK_URL"
+              label-as="tooltip"
+              class="icon-btn"
+              action-color="bg-transparent"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <style scoped lang="scss">
+.helper-box {
+  padding: 10px;
+  background-color: var(--box-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--border-radius);
+
+  .helper-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .field-label {
+    color: var(--input-label);
+  }
+
+  .copy-field {
+    display: flex;
+    align-items: center;
+    gap: var(--gap);
+    padding: 8px;
+    background-color: var(--input-bg);
+    border: 1px solid var(--input-border);
+    border-radius: var(--border-radius);
+    font-family: monospace;
+    font-size: 12px;
+  }
+
+  .field-value {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text);
+    border: none;
+    padding: 0;
+  }
+}
+
 .in-progress-badge {
   display: flex;
   align-items: center;
@@ -323,5 +418,15 @@ onBeforeUnmount(() => {
     border-color: var(--input-disabled-border);
     cursor: not-allowed;
   }
+}
+
+.tooltip-icon {
+  color: var(--input-label);
+  margin-left: 8px;
+  cursor: pointer;
+}
+
+.subrow-title-icon {
+  font-size: 12px;
 }
 </style>

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/Oauth2SecretForm.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/Oauth2SecretForm.vue
@@ -11,7 +11,7 @@ import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import formRulesGenerator from '@shell/utils/validators/formRules';
 import { warn } from '../../../../utils/log';
 import { AGENT_NAMESPACE } from '../../../../product';
-import { AiAgentAPIEvent } from '../../../../types';
+import { AIAgentAPIEvent } from '../../../../types';
 import { AiAgentConfigOAuth2SecretPayload } from '../../types';
 import DiscoveryBanner from '../../../../components/DiscoveryBanner/DiscoveryBanner.vue';
 import { useAIAgentApiComposable } from '../../../../composables/useAIAgentApiComposable';
@@ -123,7 +123,7 @@ async function confirmMetadataDiscovery() {
 
   const data = await fetchMcpAuthenticationMetadata({ mcpUrl: props.mcpUrl });
 
-  if (!data || data.code === AiAgentAPIEvent.Error) {
+  if (!data || data.code === AIAgentAPIEvent.Error) {
     mcpScopes.value = [];
 
     metadataDiscoveryStatus.value = {
@@ -134,7 +134,7 @@ async function confirmMetadataDiscovery() {
     return;
   }
 
-  if (data.code === AiAgentAPIEvent.Abort) {
+  if (data.code === AIAgentAPIEvent.Abort) {
     metadataDiscoveryStatus.value = { result: 'info' };
 
     return;
@@ -156,7 +156,7 @@ async function confirmClientInfoDiscovery() {
 
   const data = await fetchMcpAuthenticationClientInfo({ metadataEndpoint: props.value.metadataEndpoint || '' });
 
-  if (!data || data.code === AiAgentAPIEvent.Error) {
+  if (!data || data.code === AIAgentAPIEvent.Error) {
     clientInfoDiscoveryStatus.value = {
       result:  'warning',
       message: data?.message || ''
@@ -165,7 +165,7 @@ async function confirmClientInfoDiscovery() {
     return;
   }
 
-  if (data.code === AiAgentAPIEvent.Abort) {
+  if (data.code === AIAgentAPIEvent.Abort) {
     clientInfoDiscoveryStatus.value = { result: 'info' };
 
     return;

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/Oauth2SecretForm.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/Oauth2SecretForm.vue
@@ -1,0 +1,327 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { useStore } from 'vuex';
+import { useI18n } from '@shell/composables/useI18n';
+import { base64Decode } from '@shell/utils/crypto';
+import { SECRET } from '@shell/config/types';
+import { _EDIT, _VIEW } from '@shell/config/query-params';
+import Password from '@shell/components/form/Password.vue';
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+import formRulesGenerator from '@shell/utils/validators/formRules';
+import { warn } from '../../../../utils/log';
+import { AGENT_NAMESPACE } from '../../../../product';
+import { AiAgentAPIEvent } from '../../../../types';
+import { AiAgentConfigOAuth2SecretPayload } from '../../types';
+import DiscoveryBanner from '../../../../components/DiscoveryBanner/DiscoveryBanner.vue';
+import { useAIAgentApiComposable } from '../../../../composables/useAIAgentApiComposable';
+
+interface DiscoveryStatus {
+  result?: 'success' | 'warning' | 'info' | null;
+  message?: string;
+}
+
+const store = useStore();
+const { t } = useI18n(store);
+
+const validators = (key: string) => formRulesGenerator(t, { key });
+
+const props = defineProps({
+  secretName: {
+    type:     String,
+    default:  '',
+  },
+  value: {
+    type:     Object as () => AiAgentConfigOAuth2SecretPayload | null,
+    default:  null,
+  },
+  mcpUrl: {
+    type:     String,
+    default:  '',
+  },
+  apiComposable: {
+    type:     Object as () => ReturnType<typeof useAIAgentApiComposable>,
+    default:  () => ({}),
+  },
+});
+
+const {
+  fetchMcpAuthenticationMetadata,
+  cancelFetchMcpAuthenticationMetadata,
+  fetchMcpAuthenticationClientInfo,
+  cancelFetchMcpAuthenticationClientInfo,
+  fetchMcpAuthenticationScopes,
+} = props.apiComposable;
+
+const emit = defineEmits(['update:value']);
+
+const mcpScopes = ref<string[] | null>(null);
+
+const metadataDiscoveryStatus = ref<DiscoveryStatus>({});
+const clientInfoDiscoveryStatus = ref<DiscoveryStatus>({});
+
+const isRequiredRule = (key: string) => {
+  const validator = validators(t(key));
+
+  return [
+    validator.required,
+  ];
+};
+
+async function fetchSecret() {
+  if (!props.secretName) {
+    return;
+  }
+
+  if (!!props.value) {
+    return;
+  }
+
+  try {
+    const secret = await store.dispatch(`management/find`, {
+      type: SECRET,
+      id:   `${ AGENT_NAMESPACE }/${ props.secretName }`,
+      opt:  { watch: true }
+    });
+
+    if (secret?.data) {
+      updateSecretValues({
+        metadataEndpoint: base64Decode(secret.data['metadataEndpoint'] || ''),
+        clientID:         base64Decode(secret.data['clientID'] || ''),
+        clientSecret:     base64Decode(secret.data['clientSecret'] || ''),
+        scopes:           base64Decode(secret.data['scope'] || '')?.split(' ').filter((f: string) => !!f) || []
+      });
+    }
+  } catch (err) {
+    warn(`Unable to fetch the ${ props.secretName } secret: `, { err });
+  }
+};
+
+/**
+ * Fetches the scopes supported by the MCP (Multi-Cluster Platform) for OAuth2 authentication.
+ * It uses the mcpScopesCache to avoid unnecessary API calls if the scopes have already been fetched
+ * to populate the scopes dropdown.
+ */
+async function fetchMcpScopesOptions() {
+  if (!props.mcpUrl || mcpScopes.value !== null || !props.value) {
+    return;
+  }
+
+  metadataDiscoveryStatus.value = { result: null };
+
+  mcpScopes.value = await fetchMcpAuthenticationScopes({ mcpUrl: props.mcpUrl });
+
+  metadataDiscoveryStatus.value = { result: 'info' };
+}
+
+async function confirmMetadataDiscovery() {
+  if (!props.mcpUrl) {
+    return;
+  }
+
+  metadataDiscoveryStatus.value = { result: null };
+
+  const data = await fetchMcpAuthenticationMetadata({ mcpUrl: props.mcpUrl });
+
+  if (!data || data.code === AiAgentAPIEvent.Error) {
+    mcpScopes.value = [];
+
+    metadataDiscoveryStatus.value = {
+      result:  'warning',
+      message: data?.message || ''
+    };
+
+    return;
+  }
+
+  if (data.code === AiAgentAPIEvent.Abort) {
+    metadataDiscoveryStatus.value = { result: 'info' };
+
+    return;
+  }
+
+  mcpScopes.value = data.scopesSupported || [];
+
+  updateSecretValues({ metadataEndpoint: data.metadataEndpoint });
+
+  metadataDiscoveryStatus.value = { result: 'success' };
+}
+
+async function confirmClientInfoDiscovery() {
+  if (!props.value?.metadataEndpoint) {
+    return;
+  }
+
+  clientInfoDiscoveryStatus.value = { result: null };
+
+  const data = await fetchMcpAuthenticationClientInfo({ metadataEndpoint: props.value.metadataEndpoint || '' });
+
+  if (!data || data.code === AiAgentAPIEvent.Error) {
+    clientInfoDiscoveryStatus.value = {
+      result:  'warning',
+      message: data?.message || ''
+    };
+
+    return;
+  }
+
+  if (data.code === AiAgentAPIEvent.Abort) {
+    clientInfoDiscoveryStatus.value = { result: 'info' };
+
+    return;
+  }
+
+  updateSecretValues({
+    clientID:     data.clientId,
+    clientSecret: data.clientSecret
+  });
+
+  clientInfoDiscoveryStatus.value = { result: 'success' };
+}
+
+function updateSecretValues(payload: Partial<AiAgentConfigOAuth2SecretPayload>) {
+  const newValues = Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => value !== undefined)
+  );
+
+  emit('update:value', {
+    ...(props.value || {}),
+    ...newValues
+  });
+}
+
+function cancelMetadataDiscovery() {
+  cancelFetchMcpAuthenticationMetadata();
+
+  metadataDiscoveryStatus.value = { result: 'info' };
+}
+
+function cancelClientInfoDiscovery() {
+  cancelFetchMcpAuthenticationClientInfo();
+
+  clientInfoDiscoveryStatus.value = { result: 'info' };
+}
+
+onMounted(async() => {
+  await fetchSecret();
+
+  await fetchMcpScopesOptions();
+});
+
+onBeforeUnmount(() => {
+  cancelMetadataDiscovery();
+  cancelClientInfoDiscovery();
+});
+</script>
+
+<template>
+  <div class="row">
+    <DiscoveryBanner
+      :status="metadataDiscoveryStatus"
+      translation-key="aiConfig.form.section.aiAgent.fields.oauth2.metadata.discoverInfo"
+      @confirm="confirmMetadataDiscovery"
+      @cancel="cancelMetadataDiscovery"
+    />
+  </div>
+  <div class="row">
+    <div class="col span-12 in-progress-badge">
+      <LabeledInput
+        :value="props.value?.metadataEndpoint || ''"
+        :label="t('aiConfig.form.section.aiAgent.fields.oauth2.metadata.label')"
+        :placeholder="t('aiConfig.form.section.aiAgent.fields.oauth2.metadata.placeholder')"
+        :rules="isRequiredRule('aiConfig.form.section.aiAgent.fields.oauth2.metadata.label')"
+        :required="true"
+        :disabled="metadataDiscoveryStatus?.result === null"
+        @update:value="(val: string) => updateSecretValues({ metadataEndpoint: val })"
+      />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col span-12 in-progress-badge">
+      <LabeledSelect
+        v-if="mcpScopes?.length"
+        :value="props.value?.scopes || []"
+        :label="t('aiConfig.form.section.aiAgent.fields.oauth2.scopes.label')"
+        :options="mcpScopes || []"
+        :taggable="true"
+        :multiple="true"
+        :placeholder="t('aiConfig.form.section.aiAgent.fields.oauth2.scopes.placeholder.select', { count: mcpScopes?.length || 0 }, true)"
+        :disabled="metadataDiscoveryStatus?.result === null"
+        @update:value="(val: string[]) => updateSecretValues({ scopes: val })"
+      />
+      <LabeledInput
+        v-else
+        :value="props.value?.scopes?.join(' ') || ''"
+        :label="t('aiConfig.form.section.aiAgent.fields.oauth2.scopes.label')"
+        :placeholder="t('aiConfig.form.section.aiAgent.fields.oauth2.scopes.placeholder.input')"
+        :disabled="metadataDiscoveryStatus?.result === null"
+        @update:value="(val: string) => updateSecretValues({ scopes: val?.split(' ').filter((f: string) => !!f) })"
+      />
+      <i
+        v-if="metadataDiscoveryStatus?.result === null"
+        class="icon icon-spinner icon-spin icon-lg"
+      />
+    </div>
+  </div>
+
+  <div class="row">
+    <DiscoveryBanner
+      :status="clientInfoDiscoveryStatus"
+      translation-key="aiConfig.form.section.aiAgent.fields.oauth2.client.discoverInfo"
+      @confirm="confirmClientInfoDiscovery"
+      @cancel="cancelClientInfoDiscovery"
+    />
+  </div>
+  <div class="row">
+    <div class="col span-6">
+      <LabeledInput
+        :value="props.value?.clientID || ''"
+        :label="t('aiConfig.form.section.aiAgent.fields.oauth2.clientId.label')"
+        :placeholder="t('aiConfig.form.section.aiAgent.fields.oauth2.clientId.placeholder')"
+        :required="true"
+        :rules="isRequiredRule('aiConfig.form.section.aiAgent.fields.oauth2.clientId.label')"
+        :disabled="clientInfoDiscoveryStatus?.result === null"
+        @update:value="(val: string) => updateSecretValues({ clientID: val })"
+      />
+    </div>
+    <div class="col span-6 in-progress-badge">
+      <Password
+        :class="{
+          'in-progress-discovery': clientInfoDiscoveryStatus?.result === null,
+        }"
+        :value="props.value?.clientSecret || ''"
+        :label="t('aiConfig.form.section.aiAgent.fields.oauth2.clientSecret.label')"
+        :required="true"
+        :rules="isRequiredRule('aiConfig.form.section.aiAgent.fields.oauth2.clientSecret.label')"
+        :mode="clientInfoDiscoveryStatus?.result === null ? _VIEW : _EDIT"
+        @update:value="(val: string) => updateSecretValues({ clientSecret: val })"
+      />
+      <i
+        v-if="clientInfoDiscoveryStatus?.result === null"
+        class="icon icon-spinner icon-spin icon-lg"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.in-progress-badge {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+
+  div {
+    width: 100%;
+  }
+}
+
+.in-progress-discovery {
+  :deep() .labeled-input {
+    color: var(--input-disabled-text);
+    background-color: var(--input-disabled-bg);
+    outline-width: 0;
+    border-color: var(--input-disabled-border);
+    cursor: not-allowed;
+  }
+}
+</style>

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/Oauth2SecretForm.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/Oauth2SecretForm.vue
@@ -8,7 +8,7 @@ import { _EDIT, _VIEW } from '@shell/config/query-params';
 import Password from '@shell/components/form/Password.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
-import CopyToClipboard from '@shell/components/CopyToClipboard.vue';
+import DetailText from '@shell/components/DetailText.vue';
 import formRulesGenerator from '@shell/utils/validators/formRules';
 import { warn } from '../../../../utils/log';
 import { AGENT_NAME, AGENT_NAMESPACE, AGENT_REST_API_PATH } from '../../../../product';
@@ -308,53 +308,25 @@ onBeforeUnmount(() => {
   </div>
 
   <div class="helper-box">
-    <h4>
-      {{ t('aiConfig.form.section.aiAgent.fields.oauth2.helper.title') }}
-      <i
-        v-clean-tooltip="t('aiConfig.form.section.aiAgent.fields.oauth2.helper.tooltip')"
-        class="icon icon-info tooltip-icon subrow-title-icon"
-      />
-    </h4>
+    <div class="helper-title">
+      <h3 class="m-0">
+        {{ t('aiConfig.form.section.aiAgent.fields.oauth2.helper.title') }}
+      </h3>
+    </div>
     <div class="row">
       <div class="col span-6">
-        <div class="helper-field">
-          <label class="field-label">
-            {{ t('aiConfig.form.section.aiAgent.fields.oauth2.homepageUrl.label') }}
-          </label>
-          <div class="copy-field">
-            <input
-              class="field-value"
-              :value="HOME_PAGE_URL"
-              readonly
-            />
-            <CopyToClipboard
-              :text="HOME_PAGE_URL"
-              label-as="tooltip"
-              class="icon-btn"
-              action-color="bg-transparent"
-            />
-          </div>
-        </div>
+        <DetailText
+          class="helper-field"
+          :value="HOME_PAGE_URL"
+          label-key="aiConfig.form.section.aiAgent.fields.oauth2.homepageUrl.label"
+        />
       </div>
       <div class="col span-6">
-        <div class="helper-field">
-          <label class="field-label">
-            {{ t('aiConfig.form.section.aiAgent.fields.oauth2.callbackUrl.label') }}
-          </label>
-          <div class="copy-field">
-            <input
-              class="field-value"
-              :value="CALLBACK_URL"
-              readonly
-            />
-            <CopyToClipboard
-              :text="CALLBACK_URL"
-              label-as="tooltip"
-              class="icon-btn"
-              action-color="bg-transparent"
-            />
-          </div>
-        </div>
+        <DetailText
+          class="helper-field"
+          :value="CALLBACK_URL"
+          label-key="aiConfig.form.section.aiAgent.fields.oauth2.callbackUrl.label"
+        />
       </div>
     </div>
   </div>
@@ -362,41 +334,30 @@ onBeforeUnmount(() => {
 
 <style scoped lang="scss">
 .helper-box {
-  padding: 10px;
   background-color: var(--box-bg);
-  border: 1px solid var(--border);
   border-radius: var(--border-radius);
+  padding: 16px;
+
+  .helper-title {
+    padding: 4px 0 20px 0;
+  }
 
   .helper-field {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  .field-label {
-    color: var(--input-label);
-  }
-
-  .copy-field {
-    display: flex;
-    align-items: center;
-    gap: var(--gap);
-    padding: 8px;
-    background-color: var(--input-bg);
-    border: 1px solid var(--input-border);
-    border-radius: var(--border-radius);
-    font-family: monospace;
-    font-size: 12px;
-  }
-
-  .field-value {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--text);
-    border: none;
-    padding: 0;
+    :deep(h5) {
+      margin-bottom: 8px;
+    }
+    :deep(.monospace) {
+      display: block;
+      white-space: nowrap;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+    :deep(.btn) {
+      // btn-sm
+      padding: 0 12px;
+      min-height: 30px;
+      line-height: 28px;
+    }
   }
 }
 
@@ -418,15 +379,5 @@ onBeforeUnmount(() => {
     border-color: var(--input-disabled-border);
     cursor: not-allowed;
   }
-}
-
-.tooltip-icon {
-  color: var(--input-label);
-  margin-left: 8px;
-  cursor: pointer;
-}
-
-.subrow-title-icon {
-  font-size: 12px;
 }
 </style>

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/__tests__/Oauth2SecretForm.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/__tests__/Oauth2SecretForm.test.ts
@@ -54,10 +54,10 @@ jest.mock('@shell/components/form/LabeledSelect.vue', () => ({
   }
 }));
 
-jest.mock('@shell/components/CopyToClipboard.vue', () => ({
+jest.mock('@shell/components/DetailText.vue', () => ({
   default: {
-    name:     'CopyToClipboard',
-    props:    ['text', 'labelAs', 'class', 'actionColor'],
+    name:     'DetailText',
+    props:    ['value', 'label-key', 'class'],
     template: '<div />'
   }
 }));
@@ -88,9 +88,8 @@ const requiredSetup = () => ({
       LabeledSelect:      true,
       LabeledInput:       true,
       DiscoveryBanner:    true,
-      CopyToClipboard:    true,
+      DetailText:         true,
     },
-    directives: { 'clean-tooltip': jest.fn() },
   }
 });
 

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/__tests__/Oauth2SecretForm.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/__tests__/Oauth2SecretForm.test.ts
@@ -54,6 +54,14 @@ jest.mock('@shell/components/form/LabeledSelect.vue', () => ({
   }
 }));
 
+jest.mock('@shell/components/CopyToClipboard.vue', () => ({
+  default: {
+    name:     'CopyToClipboard',
+    props:    ['text', 'labelAs', 'class', 'actionColor'],
+    template: '<div />'
+  }
+}));
+
 const mockApiComposable = {
   fetchMcpAuthenticationMetadata:       jest.fn().mockResolvedValue({ scopesSupported: ['openid', 'profile', 'email'] }),
   cancelFetchMcpAuthenticationMetadata: jest.fn(),
@@ -80,7 +88,9 @@ const requiredSetup = () => ({
       LabeledSelect:      true,
       LabeledInput:       true,
       DiscoveryBanner:    true,
-    }
+      CopyToClipboard:    true,
+    },
+    directives: { 'clean-tooltip': jest.fn() },
   }
 });
 

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/__tests__/Oauth2SecretForm.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/__tests__/Oauth2SecretForm.test.ts
@@ -2,7 +2,7 @@ import { shallowMount, flushPromises } from '@vue/test-utils';
 import { Buffer } from 'buffer';
 import Oauth2SecretForm from '../Oauth2SecretForm.vue';
 import { AiAgentConfigOAuth2SecretPayload } from '../../../types';
-import { AiAgentAPIEvent } from '../../../../../types';
+import { AIAgentAPIEvent } from '../../../../../types';
 
 const mockStore = { dispatch: jest.fn() };
 
@@ -435,7 +435,7 @@ describe('Oauth2SecretForm', () => {
       const payload = mockOauth2Payload();
 
       mockApiComposable.fetchMcpAuthenticationScopes.mockResolvedValueOnce([]);
-      mockApiComposable.fetchMcpAuthenticationMetadata.mockResolvedValueOnce({ code: AiAgentAPIEvent.Error });
+      mockApiComposable.fetchMcpAuthenticationMetadata.mockResolvedValueOnce({ code: AIAgentAPIEvent.Error });
 
       const wrapper = shallowMount(Oauth2SecretForm, {
         ...requiredSetup(),
@@ -489,7 +489,7 @@ describe('Oauth2SecretForm', () => {
 
       // fetchMcpAuthenticationScopes is mocked -> doesn't call fetchMcpAuthenticationMetadata
       mockApiComposable.fetchMcpAuthenticationMetadata = jest.fn().mockResolvedValueOnce({
-        code:    AiAgentAPIEvent.Error,
+        code:    AIAgentAPIEvent.Error,
         message: 'Metadata endpoint unreachable'
       });
 
@@ -619,7 +619,7 @@ describe('Oauth2SecretForm', () => {
       const payload = mockOauth2Payload();
 
       mockApiComposable.fetchMcpAuthenticationClientInfo.mockResolvedValueOnce({
-        code:    AiAgentAPIEvent.Error,
+        code:    AIAgentAPIEvent.Error,
         message: 'Failed to retrieve client info'
       });
 
@@ -644,7 +644,7 @@ describe('Oauth2SecretForm', () => {
     it('should handle client info discovery abort', async() => {
       const payload = mockOauth2Payload();
 
-      mockApiComposable.fetchMcpAuthenticationClientInfo.mockResolvedValueOnce({ code: AiAgentAPIEvent.Abort });
+      mockApiComposable.fetchMcpAuthenticationClientInfo.mockResolvedValueOnce({ code: AIAgentAPIEvent.Abort });
 
       const wrapper = shallowMount(Oauth2SecretForm, {
         ...requiredSetup(),

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/__tests__/Oauth2SecretForm.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/__tests__/Oauth2SecretForm.test.ts
@@ -1,0 +1,1041 @@
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { Buffer } from 'buffer';
+import Oauth2SecretForm from '../Oauth2SecretForm.vue';
+import { AiAgentConfigOAuth2SecretPayload } from '../../../types';
+import { AiAgentAPIEvent } from '../../../../../types';
+
+const mockStore = { dispatch: jest.fn() };
+
+jest.mock('vuex', () => ({ useStore: jest.fn(() => mockStore) }));
+
+jest.mock('@shell/composables/useI18n', () => ({
+  useI18n: jest.fn(() => ({
+    t:     (key: string) => key,
+    store: mockStore
+  }))
+}));
+
+jest.mock('@shell/utils/crypto', () => ({
+  base64Decode: jest.fn((value: string) => {
+    if (value === 'bWV0YWRhdGFFbmRwb2ludA==') {
+      return 'metadataEndpoint';
+    }
+    if (value === 'Y2xpZW50SWQxMjM=') {
+      return 'clientId123';
+    }
+    if (value === 'Y2xpZW50U2VjcmV0NDU2') {
+      return 'clientSecret456';
+    }
+    if (value === 'b3BlbmlkIHByb2ZpbGUgZW1haWw=') {
+      return 'openid profile email';
+    }
+
+    return Buffer.from(value, 'base64').toString('utf-8');
+  })
+}));
+
+jest.mock('../../../../../utils/log', () => ({ warn: jest.fn() }));
+
+jest.mock('@shell/components/form/Password.vue', () => ({
+  default: {
+    name:     'Password',
+    template: '<input class="password-field" />',
+    props:    ['value', 'label', 'required', 'rules', 'mode', 'class'],
+    emits:    ['update:value']
+  }
+}));
+
+jest.mock('@shell/components/form/LabeledSelect.vue', () => ({
+  default: {
+    name:     'LabeledSelect',
+    template: '<select class="labeled-select" />',
+    props:    ['value', 'label', 'options', 'taggable', 'multiple', 'placeholder', 'disabled'],
+    emits:    ['update:value']
+  }
+}));
+
+const mockApiComposable = {
+  fetchMcpAuthenticationMetadata:       jest.fn().mockResolvedValue({ scopesSupported: ['openid', 'profile', 'email'] }),
+  cancelFetchMcpAuthenticationMetadata: jest.fn(),
+  fetchMcpAuthenticationClientInfo:     jest.fn().mockResolvedValue({
+    clientId:     'discovered-client-id',
+    clientSecret: 'discovered-client-secret'
+  }),
+  cancelFetchMcpAuthenticationClientInfo: jest.fn(),
+  fetchMcpAuthenticationScopes:           jest.fn().mockResolvedValue(['openid', 'profile', 'email'])
+} as any;
+
+const mockOauth2Payload = (): AiAgentConfigOAuth2SecretPayload => ({
+  metadataEndpoint: 'https://oauth.example.com/.well-known/openid-configuration',
+  clientID:         'client-id-123',
+  clientSecret:     'client-secret-456',
+  scopes:           ['openid', 'profile', 'email']
+});
+
+const requiredSetup = () => ({
+  global: {
+    provide: { store: mockStore },
+    stubs:   {
+      Password:           true,
+      LabeledSelect:      true,
+      LabeledInput:       true,
+      DiscoveryBanner:    true,
+    }
+  }
+});
+
+describe('Oauth2SecretForm', () => {
+  beforeEach(() => {
+    mockStore.dispatch.mockResolvedValue({
+      data: {
+        metadataEndpoint: 'bWV0YWRhdGFFbmRwb2ludA==',
+        clientID:         'Y2xpZW50SWQxMjM=',
+        clientSecret:     'Y2xpZW50U2VjcmV0NDU2',
+        scope:            'b3BlbmlkIHByb2ZpbGUgZW1haWw='
+      }
+    });
+  });
+
+  describe('Component Initialization', () => {
+    it('should render the component with all form fields', () => {
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         null,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      expect(wrapper.findComponent({ name: 'DiscoveryBanner' }).exists()).toBe(true);
+      expect(wrapper.findComponent({ name: 'LabeledInput' }).exists()).toBe(true);
+      expect(wrapper.findComponent({ name: 'Password' }).exists()).toBe(true);
+    });
+
+    it('should initialize with null mcpScopes when no scopes discovered yet', () => {
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         null,
+          mcpUrl:        '',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      expect(vm.mcpScopes).toBeNull();
+    });
+
+    it('should initialize discovery statuses as empty objects', () => {
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         null,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      expect(vm.metadataDiscoveryStatus).toEqual({});
+      expect(vm.clientInfoDiscoveryStatus).toEqual({});
+    });
+  });
+
+  describe('Secret Value Handling', () => {
+    it('should render initial value in form fields', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      expect(vm.value.metadataEndpoint).toBe(payload.metadataEndpoint);
+      expect(vm.value.clientID).toBe(payload.clientID);
+      expect(vm.value.clientSecret).toBe(payload.clientSecret);
+      expect(vm.value.scopes).toEqual(payload.scopes);
+    });
+
+    it('should emit update event when metadata endpoint is changed', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.updateSecretValues({ metadataEndpoint: 'https://new-oauth.example.com' });
+
+      const emitted = wrapper.emitted('update:value');
+
+      expect(emitted).toBeTruthy();
+      expect(emitted![0][0]).toEqual({
+        ...payload,
+        metadataEndpoint: 'https://new-oauth.example.com'
+      });
+    });
+
+    it('should emit update event when client ID is changed', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.updateSecretValues({ clientID: 'new-client-id' });
+
+      const emitted = wrapper.emitted('update:value');
+
+      expect(emitted).toBeTruthy();
+      expect(emitted![0][0]).toEqual({
+        ...payload,
+        clientID: 'new-client-id'
+      });
+    });
+
+    it('should emit update event when client secret is changed', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.updateSecretValues({ clientSecret: 'new-secret' });
+
+      const emitted = wrapper.emitted('update:value');
+
+      expect(emitted).toBeTruthy();
+      expect(emitted![0][0]).toEqual({
+        ...payload,
+        clientSecret: 'new-secret'
+      });
+    });
+
+    it('should emit update event when scopes are changed', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.updateSecretValues({ scopes: ['openid', 'offline_access'] });
+
+      const emitted = wrapper.emitted('update:value');
+
+      expect(emitted).toBeTruthy();
+      expect(emitted![0][0]).toEqual({
+        ...payload,
+        scopes: ['openid', 'offline_access']
+      });
+    });
+
+    it('should only include defined values in update payload', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.updateSecretValues({
+        clientID:     'new-id',
+        clientSecret: undefined
+      });
+
+      const emitted = wrapper.emitted('update:value');
+
+      expect(emitted![0][0]).toEqual({
+        ...payload,
+        clientID: 'new-id'
+      });
+      expect((emitted![0][0] as any).clientSecret).not.toBeUndefined();
+    });
+  });
+
+  describe('Secret Fetching from Kubernetes', () => {
+    it('should fetch secret from Kubernetes on mount if no value provided', async() => {
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         null,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith('management/find', expect.objectContaining({
+        type: expect.any(String),
+        id:   expect.stringContaining('oauth2-secret')
+      }));
+    });
+
+    it('should not fetch secret if value is already provided', async() => {
+      const payload = mockOauth2Payload();
+
+      mockStore.dispatch.mockClear();
+
+      shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith('management/find', expect.anything());
+    });
+
+    it('should emit update with fetched secret values', async() => {
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         null,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      await wrapper.vm.$nextTick();
+
+      const emitted = wrapper.emitted('update:value');
+
+      expect(emitted).toBeTruthy();
+      expect(emitted![0][0]).toEqual(expect.objectContaining({
+        metadataEndpoint: 'metadataEndpoint',
+        clientID:         'clientId123',
+        clientSecret:     'clientSecret456',
+        scopes:           ['openid', 'profile', 'email']
+      }));
+    });
+
+    it('should not fetch secret if secretName is empty', async() => {
+      mockStore.dispatch.mockClear();
+
+      shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    '',
+          value:         null,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      expect(mockStore.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Metadata Discovery', () => {
+    it('should fetch MCP scopes on mount if mcpUrl and value provided', async() => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationMetadata.mockResolvedValueOnce({
+        scopesSupported:  ['openid', 'profile', 'email', 'offline_access'],
+        metadataEndpoint: payload.metadataEndpoint
+      });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(mockApiComposable.fetchMcpAuthenticationScopes).toHaveBeenCalledWith({ mcpUrl: 'http://mcp-server.local' });
+    });
+
+    it('should set mcpScopes from discovery response', async() => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationMetadata.mockResolvedValueOnce({
+        scopesSupported:  ['openid', 'profile', 'email'],
+        metadataEndpoint: payload.metadataEndpoint
+      });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      await flushPromises();
+
+      const vm = wrapper.vm as any;
+
+      expect(vm.mcpScopes).toEqual(['openid', 'profile', 'email']);
+    });
+
+    it('should handle metadata discovery error', async() => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationScopes.mockResolvedValueOnce([]);
+      mockApiComposable.fetchMcpAuthenticationMetadata.mockResolvedValueOnce({ code: AiAgentAPIEvent.Error });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      await flushPromises();
+
+      const vm = wrapper.vm as any;
+
+      expect(vm.mcpScopes).toEqual([]);
+    });
+
+    it('should confirm metadata discovery with force refresh', async() => {
+      const payload = mockOauth2Payload();
+      const newEndpoint = 'https://new-oauth.example.com/.well-known/openid-configuration';
+
+      // First call during mount, second call in confirmMetadataDiscovery
+      mockApiComposable.fetchMcpAuthenticationMetadata
+        .mockResolvedValueOnce({
+          scopesSupported:  ['openid', 'profile'],
+          metadataEndpoint: newEndpoint
+        });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      await wrapper.vm.$nextTick();
+      await vm.confirmMetadataDiscovery();
+
+      expect(mockApiComposable.fetchMcpAuthenticationMetadata).toHaveBeenCalledWith({ mcpUrl: 'http://mcp-server.local' });
+      expect(vm.metadataDiscoveryStatus.result).toBe('success');
+    });
+
+    it('should set error status when metadata discovery fails', async() => {
+      const payload = mockOauth2Payload();
+
+      // fetchMcpAuthenticationScopes is mocked -> doesn't call fetchMcpAuthenticationMetadata
+      mockApiComposable.fetchMcpAuthenticationMetadata = jest.fn().mockResolvedValueOnce({
+        code:    AiAgentAPIEvent.Error,
+        message: 'Metadata endpoint unreachable'
+      });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      await wrapper.vm.$nextTick();
+      await vm.confirmMetadataDiscovery();
+
+      expect(vm.metadataDiscoveryStatus.result).toBe('warning');
+      expect(vm.metadataDiscoveryStatus.message).toBe('Metadata endpoint unreachable');
+    });
+
+    it('should handle metadata discovery abort', async() => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationMetadata.mockResolvedValueOnce({ code: 'ABORT' });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      await vm.confirmMetadataDiscovery();
+
+      expect(vm.metadataDiscoveryStatus.result).toBe('info');
+    });
+
+    it('should cancel metadata discovery', async() => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.metadataDiscoveryStatus.result = null;
+      vm.cancelMetadataDiscovery();
+
+      expect(mockApiComposable.cancelFetchMcpAuthenticationMetadata).toHaveBeenCalled();
+      expect(vm.metadataDiscoveryStatus.result).toBe('info');
+    });
+  });
+
+  describe('Client Info Discovery', () => {
+    it('should confirm client info discovery', async() => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationClientInfo.mockResolvedValueOnce({
+        clientId:     'discovered-client-id',
+        clientSecret: 'discovered-client-secret'
+      });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      await vm.confirmClientInfoDiscovery();
+
+      expect(mockApiComposable.fetchMcpAuthenticationClientInfo).toHaveBeenCalledWith({ metadataEndpoint: payload.metadataEndpoint });
+      expect(vm.clientInfoDiscoveryStatus.result).toBe('success');
+    });
+
+    it('should update client ID and secret from discovery', async() => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationClientInfo.mockResolvedValueOnce({
+        clientId:     'discovered-client-id',
+        clientSecret: 'discovered-client-secret'
+      });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      await vm.confirmClientInfoDiscovery();
+
+      const emitted = wrapper.emitted('update:value');
+
+      expect(emitted).toBeTruthy();
+      expect(emitted![emitted!.length - 1][0]).toEqual(expect.objectContaining({
+        clientID:     'discovered-client-id',
+        clientSecret: 'discovered-client-secret'
+      }));
+    });
+
+    it('should set error status when client info discovery fails', async() => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationClientInfo.mockResolvedValueOnce({
+        code:    AiAgentAPIEvent.Error,
+        message: 'Failed to retrieve client info'
+      });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      await vm.confirmClientInfoDiscovery();
+
+      expect(vm.clientInfoDiscoveryStatus.result).toBe('warning');
+      expect(vm.clientInfoDiscoveryStatus.message).toBe('Failed to retrieve client info');
+    });
+
+    it('should handle client info discovery abort', async() => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationClientInfo.mockResolvedValueOnce({ code: AiAgentAPIEvent.Abort });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      await vm.confirmClientInfoDiscovery();
+
+      expect(vm.clientInfoDiscoveryStatus.result).toBe('info');
+    });
+
+    it('should cancel client info discovery', async() => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.clientInfoDiscoveryStatus.result = null;
+      vm.cancelClientInfoDiscovery();
+
+      expect(mockApiComposable.cancelFetchMcpAuthenticationClientInfo).toHaveBeenCalled();
+      expect(vm.clientInfoDiscoveryStatus.result).toBe('info');
+    });
+
+    it('should not call discovery if metadata endpoint not set', async() => {
+      const payload = {
+        ...mockOauth2Payload(),
+        metadataEndpoint: ''
+      };
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      mockApiComposable.fetchMcpAuthenticationClientInfo.mockClear();
+      await vm.confirmClientInfoDiscovery();
+
+      expect(mockApiComposable.fetchMcpAuthenticationClientInfo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Scope Handling', () => {
+    it('should show scopes as select when mcpScopes available', () => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationMetadata.mockResolvedValueOnce({ scopesSupported: ['openid', 'profile', 'email', 'offline_access'] });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.mcpScopes = ['openid', 'profile', 'email'];
+
+      wrapper.vm.$forceUpdate();
+
+      expect(vm.mcpScopes).toBeTruthy();
+    });
+
+    it('should show scopes as input when mcpScopes not available', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        '',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      expect(vm.mcpScopes).toBeNull();
+    });
+
+    it('should split scopes string into array when updating', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      const scopeString = 'openid profile email';
+
+      vm.updateSecretValues({ scopes: scopeString?.split(' ').filter((f: string) => !!f) });
+
+      const emitted = wrapper.emitted('update:value');
+
+      expect((emitted![0][0] as any).scopes).toEqual(['openid', 'profile', 'email']);
+    });
+
+    it('should filter empty scopes', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      const scopeString = 'openid  profile  ';
+
+      vm.updateSecretValues({ scopes: scopeString?.split(' ').filter((f: string) => !!f) });
+
+      const emitted = wrapper.emitted('update:value');
+
+      expect((emitted![0][0] as any).scopes).toEqual(['openid', 'profile']);
+    });
+  });
+
+  describe('Lifecycle Hooks', () => {
+    it('should cancel all discovery operations on unmount', async() => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      wrapper.unmount();
+
+      expect(mockApiComposable.cancelFetchMcpAuthenticationMetadata).toHaveBeenCalled();
+      expect(mockApiComposable.cancelFetchMcpAuthenticationClientInfo).toHaveBeenCalled();
+    });
+  });
+
+  describe('Form Validation', () => {
+    it('should render with required prop passed to form inputs', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      // Component should render without errors with all required fields set
+      expect(wrapper.findComponent({ name: 'LabeledInput' }).exists()).toBe(true);
+    });
+
+    it('should handle empty form values gracefully', () => {
+      const emptyPayload = {
+        metadataEndpoint: '',
+        clientID:         '',
+        clientSecret:     '',
+        scopes:           []
+      };
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         emptyPayload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      expect(vm.value.metadataEndpoint).toBe('');
+      expect(vm.value.clientID).toBe('');
+      expect(vm.value.clientSecret).toBe('');
+    });
+
+    it('should have Password component for secret field', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const passwordComponent = wrapper.findComponent({ name: 'Password' });
+
+      expect(passwordComponent.exists()).toBe(true);
+    });
+  });
+
+  describe('Disabled States During Discovery', () => {
+    it('should set metadata discovery status to loading when starting discovery', async() => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.metadataDiscoveryStatus.result = null;
+
+      expect(vm.metadataDiscoveryStatus.result).toBeNull();
+    });
+
+    it('should set scopes when metadata discovery succeeds', async() => {
+      const payload = mockOauth2Payload();
+
+      mockApiComposable.fetchMcpAuthenticationMetadata.mockResolvedValueOnce({
+        scopesSupported:  ['openid'],
+        metadataEndpoint: payload.metadataEndpoint
+      });
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.mcpScopes = ['openid'];
+
+      expect(vm.mcpScopes).toEqual(['openid']);
+    });
+
+    it('should set client discovery status to loading when starting discovery', async() => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.clientInfoDiscoveryStatus.result = null;
+
+      expect(vm.clientInfoDiscoveryStatus.result).toBeNull();
+    });
+
+    it('should show password in view mode during client discovery', async() => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.clientInfoDiscoveryStatus.result = null;
+
+      expect(vm.clientInfoDiscoveryStatus.result).toBeNull();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty scopes array', () => {
+      const payload = {
+        ...mockOauth2Payload(),
+        scopes: []
+      };
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      expect(vm.value.scopes).toEqual([]);
+    });
+
+    it('should not fetch metadata if mcpUrl not provided', async() => {
+      mockApiComposable.fetchMcpAuthenticationMetadata.mockClear();
+
+      const payload = mockOauth2Payload();
+
+      shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        '',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      expect(mockApiComposable.fetchMcpAuthenticationMetadata).not.toHaveBeenCalled();
+    });
+
+    it('should preserve existing payload values when updating partial values', () => {
+      const payload = mockOauth2Payload();
+
+      const wrapper = shallowMount(Oauth2SecretForm, {
+        ...requiredSetup(),
+        props: {
+          secretName:    'oauth2-secret',
+          value:         payload,
+          mcpUrl:        'http://mcp-server.local',
+          apiComposable: mockApiComposable
+        }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.updateSecretValues({ clientID: 'new-id' });
+
+      const emitted = wrapper.emitted('update:value');
+      const emittedData = emitted![0][0] as any;
+
+      expect(emittedData.metadataEndpoint).toBe(payload.metadataEndpoint);
+      expect(emittedData.clientSecret).toBe(payload.clientSecret);
+      expect(emittedData.scopes).toEqual(payload.scopes);
+      expect(emittedData.clientID).toBe('new-id');
+    });
+  });
+});

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/index.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/index.vue
@@ -6,8 +6,8 @@ import { randomStr } from '@shell/utils/string';
 import Tabbed from '@shell/components/Tabbed/index.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 import ArrayList from '@shell/components/form/ArrayList.vue';
-import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import Banner from '@components/Banner/Banner.vue';
 import TextAreaAutoGrow from '@components/Form/TextArea/TextAreaAutoGrow.vue';
@@ -15,15 +15,24 @@ import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthS
 import SecretSelector from '@shell/components/form/SecretSelector.vue';
 import FileSelector from '@shell/components/form/FileSelector.vue';
 import formRulesGenerator from '@shell/utils/validators/formRules';
-import { AGENT_NAMESPACE } from '../../../product';
-import { AIAgentConfigCRD } from '../../../types';
-import { AIAgentConfigAuthType, AiAgentConfigSecretPayload } from '../types';
-import { DEFAULT_AI_AGENT } from '../../../composables/useAgentComposable';
+import { AGENT_NAMESPACE } from '../../../../product';
+import { AIAgentConfigCRD } from '../../../../types';
+import { AIAgentConfigAuthType, AiAgentConfigBasicSecretPayload, AiAgentConfigOAuth2SecretPayload } from '../../types';
+import { DEFAULT_AI_AGENT } from '../../../../composables/useAgentComposable';
+import Oauth2SecretForm from './Oauth2SecretForm.vue';
+import { useAIAgentApiComposable } from '../../../../composables/useAIAgentApiComposable';
+
+interface ValidationStatus {
+  touched: boolean;
+  focused: boolean;
+}
 
 const CA_BUNDLE_TLS_KEY = 'tls.crt';
 
 const store = useStore();
 const { t } = useI18n(store);
+
+const apiComposable = useAIAgentApiComposable();
 
 const validators = (key: string) => formRulesGenerator(t, { key });
 
@@ -56,6 +65,10 @@ const authOptions = [
   {
     label: t('aiConfig.form.section.aiAgent.options.mcp.authOptions.header'),
     value: AIAgentConfigAuthType.HEADER
+  },
+  {
+    label: t('aiConfig.form.section.aiAgent.options.mcp.authOptions.oauth2'),
+    value: AIAgentConfigAuthType.OAUTH2
   },
   {
     label: t('aiConfig.form.section.aiAgent.options.mcp.authOptions.rancher'),
@@ -103,14 +116,14 @@ const isAgentUnavailable = computed(() => {
   return !!errorMessage;
 });
 
-const agentSecrets = ref<Record<string, AiAgentConfigSecretPayload | null>>({});
+const agentSecrets = ref<Record<string, AiAgentConfigBasicSecretPayload | AiAgentConfigOAuth2SecretPayload | null>>({});
 
-const descriptionValidationStatus = ref({
+const descriptionValidationStatus = ref<ValidationStatus>({
   touched: false,
   focused: false
 });
 
-const systemPromptValidationStatus = ref({
+const systemPromptValidationStatus = ref<ValidationStatus>({
   touched: false,
   focused: false
 });
@@ -125,27 +138,34 @@ const isRequiredRule = (key: string) => {
 
 const validationErrors = computed(() => {
   return agents.value.reduce((acc, agent) => {
-    const rule = isRequiredRule('_placeholder_')[0];
+    let hasErrors = false;
 
-    const requiredFields = [
-      agent.spec.displayName,
-      agent.spec.description,
-      agent.spec.mcpURL,
-      agent.spec.systemPrompt
-    ];
+    if (
+      !agent.spec.displayName ||
+      !agent.spec.description ||
+      !agent.spec.mcpURL ||
+      !agent.spec.systemPrompt
+    ) {
+      hasErrors = true;
+    }
 
-    for (const field of requiredFields) {
-      const res = rule(field);
+    if (agent.spec.authenticationType === AIAgentConfigAuthType.OAUTH2) {
+      const payload = agentSecrets.value[agent.metadata?.name || ''] as AiAgentConfigOAuth2SecretPayload;
 
-      if (res) {
-        return {
-          ...acc,
-          [agent.metadata?.name || '']: true
-        };
+      if (
+        !payload ||
+        !payload.metadataEndpoint ||
+        !payload.clientID ||
+        !payload.clientSecret
+      ) {
+        hasErrors = true;
       }
     }
 
-    return acc;
+    return {
+      ...acc,
+      [agent.metadata?.name || '']: hasErrors
+    };
   }, {} as Record<string, boolean>);
 });
 
@@ -181,15 +201,13 @@ function updateAuthType(value: AIAgentConfigAuthType) {
 
   updateAgent(updatedSpecValue);
 
-  // Cleaning up the agentSecrets to avoid creating new secrets when the type is not BASIC
-  if (updatedSpecValue.spec.authenticationType !== AIAgentConfigAuthType.BASIC) {
-    delete agentSecrets.value[selectedAgentName.value];
+  // Cleaning up the agentSecrets
+  delete agentSecrets.value[selectedAgentName.value];
 
-    emit('update:authentication-secrets', undefined);
-  }
+  emit('update:authentication-secrets', undefined);
 }
 
-function updateBasicAuthSecret(value: AiAgentConfigSecretPayload) {
+function updateBasicAuthSecret(value: AiAgentConfigBasicSecretPayload) {
   const { selected, privateKey, publicKey } = value;
 
   // Clear the authenticationSecret fields
@@ -226,6 +244,12 @@ function updateBasicAuthSecret(value: AiAgentConfigSecretPayload) {
     });
     delete agentSecrets.value[selectedAgentName.value];
   }
+
+  emit('update:authentication-secrets', agentSecrets.value);
+}
+
+function updateOauth2AuthSecret(agent: AIAgentConfigCRD, value: Partial<AiAgentConfigOAuth2SecretPayload>) {
+  agentSecrets.value[agent.metadata?.name || ''] = value as AiAgentConfigOAuth2SecretPayload;
 
   emit('update:authentication-secrets', agentSecrets.value);
 }
@@ -473,37 +497,50 @@ watch(validationErrors, (errors) => {
               </div>
             </div>
             <div
-              v-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.BASIC && !isAgentLocked && !props.readOnly"
-              class="row"
+              v-if="!isAgentLocked && !props.readOnly"
+              class="form-values-row"
             >
-              <div class="col span-12">
-                <SelectOrCreateAuthSecret
-                  :key="selectedAgent.metadata.name + selectedAgent.spec.authenticationSecret"
-                  :value="selectedAgent.spec.authenticationSecret || undefined"
-                  :pre-select="agentSecrets[selectedAgentName]"
-                  :namespace="AGENT_NAMESPACE"
-                  :allow-ssh="false"
-                  :delegate-create-to-parent="true"
-                  :cache-secrets="true"
-                  :register-before-hook="() => {}"
-                  in-store="management"
-                  label-key="aiConfig.form.section.aiAgent.fields.authenticationSecret.label"
-                  @inputauthval="updateBasicAuthSecret"
-                />
+              <div
+                v-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.BASIC"
+                class="row"
+              >
+                <div class="col span-12">
+                  <SelectOrCreateAuthSecret
+                    :key="selectedAgent.metadata.name + selectedAgent.spec.authenticationSecret"
+                    :value="selectedAgent.spec.authenticationSecret || undefined"
+                    :pre-select="agentSecrets[selectedAgentName]"
+                    :namespace="AGENT_NAMESPACE"
+                    :allow-ssh="false"
+                    :delegate-create-to-parent="true"
+                    :cache-secrets="true"
+                    :register-before-hook="() => {}"
+                    in-store="management"
+                    label-key="aiConfig.form.section.aiAgent.fields.authenticationSecret.label"
+                    @inputauthval="updateBasicAuthSecret"
+                  />
+                </div>
               </div>
-            </div>
-            <div
-              v-else-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.HEADER && !isAgentLocked && !props.readOnly"
-              class="row"
-            >
-              <div class="col span-6">
-                <SecretSelector
-                  :value="selectedAgent.spec.authenticationSecret || undefined"
-                  :secret-name-label="t('aiConfig.form.section.aiAgent.fields.authenticationSecret.label')"
-                  :namespace="AGENT_NAMESPACE"
-                  @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, authenticationSecret: value || undefined } })"
-                />
+              <div
+                v-else-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.HEADER"
+                class="row"
+              >
+                <div class="col span-6">
+                  <SecretSelector
+                    :value="selectedAgent.spec.authenticationSecret || undefined"
+                    :secret-name-label="t('aiConfig.form.section.aiAgent.fields.authenticationSecret.label')"
+                    :namespace="AGENT_NAMESPACE"
+                    @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, authenticationSecret: value || undefined } })"
+                  />
+                </div>
               </div>
+              <Oauth2SecretForm
+                v-else-if="agent.spec.authenticationType === AIAgentConfigAuthType.OAUTH2"
+                :value="agentSecrets[agent.metadata.name] as AiAgentConfigOAuth2SecretPayload"
+                :secret-name="agent.spec.authenticationSecret"
+                :mcp-url="agent.spec.mcpURL"
+                :api-composable="apiComposable"
+                @update:value="(value: Partial<AiAgentConfigOAuth2SecretPayload>) => updateOauth2AuthSecret(agent, value)"
+              />
             </div>
           </div>
 

--- a/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/index.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/ai-agent-configs/index.vue
@@ -468,7 +468,7 @@ watch(validationErrors, (errors) => {
             {{ t('aiConfig.form.section.aiAgent.sections.mcp.title') }}
           </h3>
           <div class="row">
-            <div class="col span-12">
+            <div class="col span-6">
               <LabeledInput
                 required
                 :value="selectedAgent.spec.mcpURL"
@@ -479,91 +479,81 @@ watch(validationErrors, (errors) => {
                 @update:value="(val: string) => updateAgent({ spec: { ...selectedAgent.spec, mcpURL: val } })"
               />
             </div>
+            <div class="col span-6">
+              <LabeledSelect
+                :value="selectedAgent.spec.authenticationType"
+                :disabled="isAgentLocked || props.readOnly"
+                :label="t('aiConfig.form.section.aiAgent.fields.authenticationType.label')"
+                :options="authOptions"
+                @update:value="updateAuthType"
+              />
+            </div>
           </div>
 
-          <div class="form-values-row">
-            <h4 class="m-0">
-              {{ t('aiConfig.form.section.aiAgent.fields.authentication.title') }}
-            </h4>
-            <div class="row">
-              <div class="col span-6">
-                <LabeledSelect
-                  :value="selectedAgent.spec.authenticationType"
-                  :disabled="isAgentLocked || props.readOnly"
-                  :label="t('aiConfig.form.section.aiAgent.fields.authenticationType.label')"
-                  :options="authOptions"
-                  @update:value="updateAuthType"
+          <template v-if="!isAgentLocked && !props.readOnly">
+            <div
+              v-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.BASIC"
+              class="row"
+            >
+              <div class="col span-12">
+                <SelectOrCreateAuthSecret
+                  :key="selectedAgent.metadata.name + selectedAgent.spec.authenticationSecret"
+                  :value="selectedAgent.spec.authenticationSecret || undefined"
+                  :pre-select="agentSecrets[selectedAgentName]"
+                  :namespace="AGENT_NAMESPACE"
+                  :allow-ssh="false"
+                  :delegate-create-to-parent="true"
+                  :cache-secrets="true"
+                  :register-before-hook="() => {}"
+                  in-store="management"
+                  label-key="aiConfig.form.section.aiAgent.fields.authenticationSecret.label"
+                  @inputauthval="updateBasicAuthSecret"
                 />
               </div>
             </div>
             <div
-              v-if="!isAgentLocked && !props.readOnly"
-              class="form-values-row"
+              v-else-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.HEADER"
+              class="row"
             >
-              <div
-                v-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.BASIC"
-                class="row"
-              >
-                <div class="col span-12">
-                  <SelectOrCreateAuthSecret
-                    :key="selectedAgent.metadata.name + selectedAgent.spec.authenticationSecret"
-                    :value="selectedAgent.spec.authenticationSecret || undefined"
-                    :pre-select="agentSecrets[selectedAgentName]"
-                    :namespace="AGENT_NAMESPACE"
-                    :allow-ssh="false"
-                    :delegate-create-to-parent="true"
-                    :cache-secrets="true"
-                    :register-before-hook="() => {}"
-                    in-store="management"
-                    label-key="aiConfig.form.section.aiAgent.fields.authenticationSecret.label"
-                    @inputauthval="updateBasicAuthSecret"
-                  />
-                </div>
-              </div>
-              <div
-                v-else-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.HEADER"
-                class="row"
-              >
-                <div class="col span-6">
-                  <SecretSelector
-                    :value="selectedAgent.spec.authenticationSecret || undefined"
-                    :secret-name-label="t('aiConfig.form.section.aiAgent.fields.authenticationSecret.label')"
-                    :namespace="AGENT_NAMESPACE"
-                    @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, authenticationSecret: value || undefined } })"
-                  />
-                </div>
-              </div>
-              <Oauth2SecretForm
-                v-else-if="agent.spec.authenticationType === AIAgentConfigAuthType.OAUTH2"
-                :value="agentSecrets[agent.metadata.name] as AiAgentConfigOAuth2SecretPayload"
-                :secret-name="agent.spec.authenticationSecret"
-                :mcp-url="agent.spec.mcpURL"
-                :api-composable="apiComposable"
-                @update:value="(value: Partial<AiAgentConfigOAuth2SecretPayload>) => updateOauth2AuthSecret(agent, value)"
-              />
-            </div>
-          </div>
-
-          <div
-            v-if="!isAgentLocked && !props.readOnly"
-            class="form-values-row"
-          >
-            <h4 class="m-0">
-              {{ t('aiConfig.form.section.aiAgent.fields.caBundleRef.title') }}
-              <i
-                v-clean-tooltip="t('aiConfig.form.section.aiAgent.fields.caBundleRef.tooltip')"
-                class="icon icon-info tooltip-icon subrow-title-icon"
-              />
-            </h4>
-            <div class="row">
               <div class="col span-6">
                 <SecretSelector
-                  :value="selectedAgent.spec.caBundleRef?.name || undefined"
-                  :secret-name-label="t('aiConfig.form.section.aiAgent.fields.caBundleRef.label')"
+                  :value="selectedAgent.spec.authenticationSecret || undefined"
+                  :secret-name-label="t('aiConfig.form.section.aiAgent.fields.authenticationSecret.label')"
                   :namespace="AGENT_NAMESPACE"
-                  @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, caBundleRef: value ? { name: value, key: CA_BUNDLE_TLS_KEY } : undefined } })"
+                  @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, authenticationSecret: value || undefined } })"
                 />
               </div>
+            </div>
+            <Oauth2SecretForm
+              v-else-if="agent.spec.authenticationType === AIAgentConfigAuthType.OAUTH2"
+              :value="agentSecrets[agent.metadata.name] as AiAgentConfigOAuth2SecretPayload"
+              :secret-name="agent.spec.authenticationSecret"
+              :mcp-url="agent.spec.mcpURL"
+              :api-composable="apiComposable"
+              @update:value="(value: Partial<AiAgentConfigOAuth2SecretPayload>) => updateOauth2AuthSecret(agent, value)"
+            />
+          </template>
+        </div>
+
+        <div
+          v-if="!isAgentLocked && !props.readOnly"
+          class="form-values-row"
+        >
+          <h3 class="m-0">
+            {{ t('aiConfig.form.section.aiAgent.fields.caBundleRef.title') }}
+            <i
+              v-clean-tooltip="t('aiConfig.form.section.aiAgent.fields.caBundleRef.tooltip')"
+              class="icon icon-info tooltip-icon subrow-title-icon"
+            />
+          </h3>
+          <div class="row">
+            <div class="col span-6">
+              <SecretSelector
+                :value="selectedAgent.spec.caBundleRef?.name || undefined"
+                :secret-name-label="t('aiConfig.form.section.aiAgent.fields.caBundleRef.label')"
+                :namespace="AGENT_NAMESPACE"
+                @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, caBundleRef: value ? { name: value, key: CA_BUNDLE_TLS_KEY } : undefined } })"
+              />
             </div>
           </div>
         </div>

--- a/pkg/rancher-ai-ui/pages/settings/types.ts
+++ b/pkg/rancher-ai-ui/pages/settings/types.ts
@@ -64,10 +64,18 @@ export const enum AIAgentConfigAuthType {
   RANCHER = 'RANCHER',
   BASIC = 'BASIC',
   HEADER = 'HEADER',
+  OAUTH2 = 'OAUTH2'
 }
 
-export interface AiAgentConfigSecretPayload {
+export interface AiAgentConfigBasicSecretPayload {
   selected: '_none' | '_basic' | string;
   privateKey: string;
   publicKey: string;
+}
+
+export interface AiAgentConfigOAuth2SecretPayload {
+  clientID: string;
+  clientSecret: string;
+  metadataEndpoint: string;
+  scopes: string[];
 }

--- a/pkg/rancher-ai-ui/store/chat.ts
+++ b/pkg/rancher-ai-ui/store/chat.ts
@@ -48,6 +48,10 @@ const getters = {
     return state.chats[chatId]?.messages[messageId] || null;
   },
   processingState: (state: State) => (chatId: string) => {
+    if (!state.metadata?.chatId) {
+      return { phase: MessagePhase.Setup };
+    }
+
     const messages = Object.values(state.chats[chatId]?.messages || {});
 
     if (

--- a/pkg/rancher-ai-ui/types.ts
+++ b/pkg/rancher-ai-ui/types.ts
@@ -23,8 +23,14 @@ export const enum Tag {
   ConfirmationEnd = '</confirmation-response>',
   DocLinkStart = '<mcp-doclink>',
   DocLinkEnd = '</mcp-doclink>',
+  AuthenticationRequestStart = '<authentication>',
+  AuthenticationRequestEnd = '</authentication>',
+  TokenRefreshRequestStart = '<token-refresh>',
+  TokenRefreshRequestEnd = '</token-refresh>',
   ChatErrorStart = '<chat-error>',
   ChatErrorEnd = '</chat-error>',
+  AuthenticationErrorStart = '<auth-error>',
+  AuthenticationErrorEnd = '</auth-error>',
   ErrorStart = '<error>',
   ErrorEnd = '</error>',
   // Processing tags
@@ -99,6 +105,8 @@ export const enum MessagePhase {
   AwaitingConfirmation = 'awaitingConfirmation',
   GeneratingResponse = 'generatingResponse',
   ProcessingSubagent = 'processingSubagent',
+  ResumingAgent = 'resumingAgent',
+  RefreshingMcpToken = 'refreshingMcpToken',
   ProcessingTools = 'processingTools',
   Confirming = 'confirming',
   Finalizing = 'finalizing',
@@ -196,15 +204,12 @@ export const enum MessageTemplateComponent {
   Welcome = 'welcome',
   NoPermission = 'no-permission',
   SystemRequest = 'system-request',
+  McpAuthenticationRequest = 'mcp-authentication-request',
 }
 
 export interface MessageTemplate {
   component: MessageTemplateComponent;
-  content: {
-    message?: string;
-    principal?: any;
-    [key: string]: unknown;
-  };
+  content: { [key: string]: any; };
 }
 
 export const enum MessageLabelKey {
@@ -275,8 +280,23 @@ export const enum AiAgentAPIEvent {
   Abort = '__abort__',
 }
 
-export interface SubAgentProcessingMetadata {
+export interface McpAuthenticationRequest {
   agent: string;
+  type: string;
+  url?: string;
+}
+
+export const enum McpAuthenticationResponse {
+  Continue = 'authentication_confirmed',
+  Cancel = 'authentication_canceled',
+}
+
+export const enum McpTokenRefreshResponse {
+  Confirm = 'token_refresh_confirmed',
+}
+
+export interface SubAgentProcessingMetadata {
+  name: string;
   query?: string;
 }
 

--- a/pkg/rancher-ai-ui/types.ts
+++ b/pkg/rancher-ai-ui/types.ts
@@ -270,6 +270,11 @@ export const enum StorageType {
   Postgres = 'postgres',
 }
 
+export const enum AiAgentAPIEvent {
+  Error = '__error__',
+  Abort = '__abort__',
+}
+
 export interface SubAgentProcessingMetadata {
   agent: string;
   query?: string;

--- a/pkg/rancher-ai-ui/types.ts
+++ b/pkg/rancher-ai-ui/types.ts
@@ -98,6 +98,7 @@ export const enum HookContextTag {
 
 export const enum MessagePhase {
   Idle = 'idle',
+  Setup = 'setup',
   Initializing = 'initializing',
   Thinking = 'thinking',
   Working = 'working',

--- a/pkg/rancher-ai-ui/types.ts
+++ b/pkg/rancher-ai-ui/types.ts
@@ -276,7 +276,7 @@ export const enum StorageType {
   Postgres = 'postgres',
 }
 
-export const enum AiAgentAPIEvent {
+export const enum AIAgentAPIEvent {
   Error = '__error__',
   Abort = '__abort__',
 }

--- a/pkg/rancher-ai-ui/types.ts
+++ b/pkg/rancher-ai-ui/types.ts
@@ -210,7 +210,11 @@ export const enum MessageTemplateComponent {
 
 export interface MessageTemplate {
   component: MessageTemplateComponent;
-  content: { [key: string]: any; };
+  content: {
+    message?: string;
+    principal?: any;
+    [key: string]: unknown;
+  };
 }
 
 export const enum MessageLabelKey {

--- a/pkg/rancher-ai-ui/utils/format.ts
+++ b/pkg/rancher-ai-ui/utils/format.ts
@@ -17,6 +17,7 @@ import {
   ToolCall,
   SubAgentProcessingMetadata,
   AgentSelectionMode,
+  McpAuthenticationRequest,
 } from '../types';
 import { error } from '../utils/log';
 import { validateActionResource } from './validator';
@@ -131,24 +132,43 @@ export function formatAgentMetadata(data: string): Partial<AgentMetadata> | null
   return null;
 }
 
-export function formatSubAgentProcessingMetadata(data: string, agents: Agent[]): SubAgentProcessingMetadata | null {
+export function formatSubAgentProcessingMetadata(data: string): SubAgentProcessingMetadata | null {
   const cleaned = data.replaceAll(Tag.ProcessingSubagentInitStart, '').replaceAll(Tag.ProcessingSubagentInitEnd, '').trim();
 
   try {
     const parsed = JSON.parse(cleaned);
 
-    const agent = agents.find((a) => a.name === parsed.name);
-
-    const agentName = agent?.displayName || parsed.name;
-
-    if (agentName) {
-      return {
-        agent: agentName,
-        query: parsed.query
-      };
-    }
+    return parsed;
   } catch (err) {
     error('Failed to parse sub-agent processing metadata:', err);
+  }
+
+  return null;
+}
+
+export function formatMcpAuthenticationRequest(data: string): McpAuthenticationRequest | null {
+  const cleaned = data.replaceAll(Tag.AuthenticationRequestStart, '').replaceAll(Tag.AuthenticationRequestEnd, '').trim();
+
+  try {
+    const parsed = JSON.parse(cleaned);
+
+    return parsed;
+  } catch (error) {
+    console.error('Failed to parse MCP authentication request:', error); /* eslint-disable-line no-console */
+  }
+
+  return null;
+}
+
+export function formatMcpRefreshTokenRequest(data: string): string | null {
+  const cleaned = data.replaceAll(Tag.TokenRefreshRequestStart, '').replaceAll(Tag.TokenRefreshRequestEnd, '').trim();
+
+  try {
+    const parsed = JSON.parse(cleaned);
+
+    return parsed?.agent || null;
+  } catch (error) {
+    console.error('Failed to parse MCP token refresh request:', error); /* eslint-disable-line no-console */
   }
 
   return null;
@@ -284,6 +304,22 @@ export function formatErrorMessage(value: string): ChatError {
       return parsed;
     } catch (err) {
       error('Failed to parse error message:', err);
+    }
+  }
+
+  return { message: 'An error occurred.' };
+}
+
+export function formatAuthenticationErrorMessage(value: string): ChatError {
+  value = value.replaceAll(Tag.AuthenticationErrorStart, '').replaceAll(Tag.AuthenticationErrorEnd, '').trim();
+
+  if (value) {
+    try {
+      const parsed = JSON.parse(value);
+
+      return parsed;
+    } catch (err) {
+      error('Failed to parse authentication error message:', err);
     }
   }
 

--- a/pkg/rancher-ai-ui/utils/format.ts
+++ b/pkg/rancher-ai-ui/utils/format.ts
@@ -83,8 +83,8 @@ export function formatChatErrorMessage(data: string): ChatError {
       const parsed = JSON.parse(cleaned);
 
       return parsed;
-    } catch (e) {
-      error('Failed to parse chat error message:', e);
+    } catch (err) {
+      error('Failed to parse chat error message:', err);
     }
   }
 
@@ -153,8 +153,8 @@ export function formatMcpAuthenticationRequest(data: string): McpAuthenticationR
     const parsed = JSON.parse(cleaned);
 
     return parsed;
-  } catch (error) {
-    console.error('Failed to parse MCP authentication request:', error); /* eslint-disable-line no-console */
+  } catch (err) {
+    error('Failed to parse MCP authentication request:', err);
   }
 
   return null;
@@ -167,8 +167,8 @@ export function formatMcpRefreshTokenRequest(data: string): string | null {
     const parsed = JSON.parse(cleaned);
 
     return parsed?.agent || null;
-  } catch (error) {
-    console.error('Failed to parse MCP token refresh request:', error); /* eslint-disable-line no-console */
+  } catch (err) {
+    error('Failed to parse MCP token refresh request:', err);
   }
 
   return null;

--- a/pkg/rancher-ai-ui/utils/url.ts
+++ b/pkg/rancher-ai-ui/utils/url.ts
@@ -25,9 +25,9 @@ export function validateUrl(value = ''): boolean {
     }
 
     return true;
-  } catch (error) {
-    warn('Invalid URL format:', error);
-
-    return false;
+  } catch (err) {
+    warn('Invalid URL format:', err);
   }
+
+  return false;
 }

--- a/pkg/rancher-ai-ui/utils/url.ts
+++ b/pkg/rancher-ai-ui/utils/url.ts
@@ -1,0 +1,40 @@
+import { warn } from '../utils/log';
+
+export function validateUrl(value = ''): boolean {
+  if (!value || typeof value !== 'string') {
+    warn('URL must be a non-empty string');
+
+    return false;
+  }
+
+  // Block potentially dangerous protocols
+  if (value.includes('javascript:') || value.includes('data:')) {
+    warn('URL contains invalid protocol');
+
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+
+    // Only allow HTTPS
+    if (url.protocol !== 'https:') {
+      warn('URL must use HTTPS protocol');
+
+      return false;
+    }
+
+    // Ensure hostname exists and is valid
+    if (!url.hostname || url.hostname.length === 0) {
+      warn('URL must have a valid hostname');
+
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    warn('Invalid URL format:', error);
+
+    return false;
+  }
+}

--- a/pkg/rancher-ai-ui/utils/url.ts
+++ b/pkg/rancher-ai-ui/utils/url.ts
@@ -7,13 +7,6 @@ export function validateUrl(value = ''): boolean {
     return false;
   }
 
-  // Block potentially dangerous protocols
-  if (value.includes('javascript:') || value.includes('data:')) {
-    warn('URL contains invalid protocol');
-
-    return false;
-  }
-
   try {
     const url = new URL(value);
 


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-ui/issues/186

This change introduces the possibility to setup the Oauth2 authentication when defining the agents and handle the auth requests in the Chat.

### Settings page

The user can setup the Oauth2 fields in the settings page:

<img width="1135" height="824" alt="image" src="https://github.com/user-attachments/assets/51d4ed6e-da74-4536-8a71-0ae369236e7f" />

<img width="1135" height="824" alt="image" src="https://github.com/user-attachments/assets/a2c1a8e9-9cbe-4e13-874c-3ef69d9a811e" />

We provide copy-paste URLs to setup the third-party Oauth applications:

<img width="982" height="164" alt="image" src="https://github.com/user-attachments/assets/b494c5bc-2393-40fe-ae7a-0030334f6b87" />



### Chat panel 

The auth requests are sent to the Chat, when an agent which requires oauth2 verification is triggered. This happens for each agent executed in the single message.



https://github.com/user-attachments/assets/42ad4d46-d2c1-4504-9f8e-0e947aca5869

Before initializing new chats, the server needs to check the MCP connection of each agent in the system.
When there are many agents in the system, this can take several seconds (even ~10 seconds depending on MCP servers).

Until the chat is not ready, we want to show the new  "Preparing chat" label to be displayed in between the ws connection is open and the chat metadata is received from the server.
We are also disabling the context and the console panel to avoid any interaction with the chat while the transition is on going.

<img width="636" height="242" alt="image" src="https://github.com/user-attachments/assets/eab0992f-d160-4ae7-95a9-185602fd2402" />



### Key Changes

See comments below

