### PR TITLE
Add CA certificate bundle secret to Ai Agent config settings

### DIFF
--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -372,10 +372,16 @@ aiConfig:
           enabled:
             label: Enable this agent
             tooltip: Enable or disable this AI agent without removing its configuration
+          authentication:
+            title: Authentication
           authenticationType:
-            label: Authentication Type
+            label: Type
           authenticationSecret:
-            label: Authentication Secret
+            label: Secret
+          caBundleRef:
+            title: CA Bundle
+            label: TLS Secret
+            tooltip: 'If your MCP server uses a self-signed certificate, please provide the TLS secret name containing the CA certificate to allow the AI agent to trust the MCP server. The secret must be in the same namespace as the AI agent and contain the `tls.crt` key with a valid CA certificate. If your MCP server uses a certificate signed by a well-known CA, you can leave this field empty.'
           mcpURL:
             label: Endpoint
             placeholder: https://endpoint.mcp

--- a/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
@@ -20,6 +20,8 @@ import { AIAgentConfigCRD } from '../../../types';
 import { AIAgentConfigAuthType, AiAgentConfigSecretPayload } from '../types';
 import { DEFAULT_AI_AGENT } from '../../../composables/useAgentComposable';
 
+const CA_BUNDLE_TLS_KEY = 'tls.crt';
+
 const store = useStore();
 const { t } = useI18n(store);
 
@@ -522,7 +524,7 @@ watch(validationErrors, (errors) => {
                   :value="selectedAgent.spec.caBundleRef?.name || undefined"
                   :secret-name-label="t('aiConfig.form.section.aiAgent.fields.caBundleRef.label')"
                   :namespace="AGENT_NAMESPACE"
-                  @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, caBundleRef: value ? { name: value, key: 'tls.crt' } : undefined } })"
+                  @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, caBundleRef: value ? { name: value, key: CA_BUNDLE_TLS_KEY } : undefined } })"
                 />
               </div>
             </div>

--- a/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/AIAgentConfigs.vue
@@ -264,6 +264,7 @@ function addAgent() {
         enabled:              true,
         mcpURL:               '',
         authenticationType:   AIAgentConfigAuthType.RANCHER,
+        caBundleRef:          undefined,
         humanValidationTools: [],
         description:          '',
         systemPrompt:         '',
@@ -441,7 +442,7 @@ watch(validationErrors, (errors) => {
             {{ t('aiConfig.form.section.aiAgent.sections.mcp.title') }}
           </h3>
           <div class="row">
-            <div class="col span-6">
+            <div class="col span-12">
               <LabeledInput
                 required
                 :value="selectedAgent.spec.mcpURL"
@@ -452,47 +453,78 @@ watch(validationErrors, (errors) => {
                 @update:value="(val: string) => updateAgent({ spec: { ...selectedAgent.spec, mcpURL: val } })"
               />
             </div>
-            <div class="col span-6">
-              <LabeledSelect
-                :value="selectedAgent.spec.authenticationType"
-                :disabled="isAgentLocked || props.readOnly"
-                :label="t('aiConfig.form.section.aiAgent.fields.authenticationType.label')"
-                :options="authOptions"
-                @update:value="updateAuthType"
-              />
+          </div>
+
+          <div class="form-values-row">
+            <h4 class="m-0">
+              {{ t('aiConfig.form.section.aiAgent.fields.authentication.title') }}
+            </h4>
+            <div class="row">
+              <div class="col span-6">
+                <LabeledSelect
+                  :value="selectedAgent.spec.authenticationType"
+                  :disabled="isAgentLocked || props.readOnly"
+                  :label="t('aiConfig.form.section.aiAgent.fields.authenticationType.label')"
+                  :options="authOptions"
+                  @update:value="updateAuthType"
+                />
+              </div>
+            </div>
+            <div
+              v-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.BASIC && !isAgentLocked && !props.readOnly"
+              class="row"
+            >
+              <div class="col span-12">
+                <SelectOrCreateAuthSecret
+                  :key="selectedAgent.metadata.name + selectedAgent.spec.authenticationSecret"
+                  :value="selectedAgent.spec.authenticationSecret || undefined"
+                  :pre-select="agentSecrets[selectedAgentName]"
+                  :namespace="AGENT_NAMESPACE"
+                  :allow-ssh="false"
+                  :delegate-create-to-parent="true"
+                  :cache-secrets="true"
+                  :register-before-hook="() => {}"
+                  in-store="management"
+                  label-key="aiConfig.form.section.aiAgent.fields.authenticationSecret.label"
+                  @inputauthval="updateBasicAuthSecret"
+                />
+              </div>
+            </div>
+            <div
+              v-else-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.HEADER && !isAgentLocked && !props.readOnly"
+              class="row"
+            >
+              <div class="col span-6">
+                <SecretSelector
+                  :value="selectedAgent.spec.authenticationSecret || undefined"
+                  :secret-name-label="t('aiConfig.form.section.aiAgent.fields.authenticationSecret.label')"
+                  :namespace="AGENT_NAMESPACE"
+                  @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, authenticationSecret: value || undefined } })"
+                />
+              </div>
             </div>
           </div>
+
           <div
-            v-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.BASIC && !isAgentLocked && !props.readOnly"
-            class="row"
+            v-if="!isAgentLocked && !props.readOnly"
+            class="form-values-row"
           >
-            <div class="col span-12">
-              <SelectOrCreateAuthSecret
-                :key="selectedAgent.metadata.name + selectedAgent.spec.authenticationSecret"
-                :value="selectedAgent.spec.authenticationSecret || undefined"
-                :pre-select="agentSecrets[selectedAgentName]"
-                :namespace="AGENT_NAMESPACE"
-                :allow-ssh="false"
-                :delegate-create-to-parent="true"
-                :cache-secrets="true"
-                :register-before-hook="() => {}"
-                in-store="management"
-                label-key="aiConfig.form.section.aiAgent.fields.authenticationSecret.label"
-                @inputauthval="updateBasicAuthSecret"
+            <h4 class="m-0">
+              {{ t('aiConfig.form.section.aiAgent.fields.caBundleRef.title') }}
+              <i
+                v-clean-tooltip="t('aiConfig.form.section.aiAgent.fields.caBundleRef.tooltip')"
+                class="icon icon-info tooltip-icon subrow-title-icon"
               />
-            </div>
-          </div>
-          <div
-            v-else-if="selectedAgent.spec.authenticationType === AIAgentConfigAuthType.HEADER && !isAgentLocked && !props.readOnly"
-            class="row"
-          >
-            <div class="col span-6">
-              <SecretSelector
-                :value="selectedAgent.spec.authenticationSecret || undefined"
-                :secret-name-label="t('aiConfig.form.section.aiAgent.fields.authenticationSecret.label')"
-                :namespace="AGENT_NAMESPACE"
-                @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, authenticationSecret: value || undefined } })"
-              />
+            </h4>
+            <div class="row">
+              <div class="col span-6">
+                <SecretSelector
+                  :value="selectedAgent.spec.caBundleRef?.name || undefined"
+                  :secret-name-label="t('aiConfig.form.section.aiAgent.fields.caBundleRef.label')"
+                  :namespace="AGENT_NAMESPACE"
+                  @update:value="(value: string) => updateAgent({ spec: { ...selectedAgent.spec, caBundleRef: value ? { name: value, key: 'tls.crt' } : undefined } })"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -646,6 +678,10 @@ watch(validationErrors, (errors) => {
   color: var(--input-label);
   margin-left: 8px;
   cursor: pointer;
+}
+
+.subrow-title-icon {
+  font-size: 12px;
 }
 
 .textarea-with-validation {

--- a/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentConfigs.test.ts
@@ -613,6 +613,60 @@ describe('AIAgentConfigs.vue', () => {
       expect(emitted[0].spec.authenticationType).toBe(AIAgentConfigAuthType.BASIC);
     });
 
+    it('should update caBundleRef with name and key', () => {
+      const wrapper = shallowMount(AIAgentConfigs, {
+        ...requiredSetup(),
+        props: { value: [mockAgent()] }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.updateAgent({
+        spec: {
+          ...vm.selectedAgent.spec,
+          caBundleRef: {
+            name: 'ca-bundle-secret',
+            key:  'tls.crt'
+          }
+        }
+      });
+
+      const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+      expect(emitted[0].spec.caBundleRef?.name).toBe('ca-bundle-secret');
+      expect(emitted[0].spec.caBundleRef?.key).toBe('tls.crt');
+    });
+
+    it('should clear caBundleRef when value is cleared', () => {
+      const agent = mockAgent({
+        spec: {
+          ...mockAgent().spec,
+          caBundleRef: {
+            name: 'existing-bundle',
+            key:  'tls.crt'
+          }
+        }
+      });
+
+      const wrapper = shallowMount(AIAgentConfigs, {
+        ...requiredSetup(),
+        props: { value: [agent] }
+      });
+
+      const vm = wrapper.vm as any;
+
+      vm.updateAgent({
+        spec: {
+          ...vm.selectedAgent.spec,
+          caBundleRef: undefined
+        }
+      });
+
+      const emitted = wrapper.emitted('update:value')?.[0][0] as AIAgentConfigCRD[];
+
+      expect(emitted[0].spec.caBundleRef).toBeUndefined();
+    });
+
     it('should update systemPrompt', () => {
       const wrapper = shallowMount(AIAgentConfigs, {
         ...requiredSetup(),

--- a/pkg/rancher-ai-ui/types.ts
+++ b/pkg/rancher-ai-ui/types.ts
@@ -285,6 +285,10 @@ export interface AIAgentConfigCRD {
     mcpURL?: string;
     authenticationType: string;
     authenticationSecret?: string;
+    caBundleRef?: {
+      name: string;
+      key: string;
+    };
     humanValidationTools?: string[];
     systemPrompt?: string;
     toolSet?: string;


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-ui/issues/204

### Screenshots

- Moved the authentication type and authentication secret in the new `Authentication` section - when selecting `Basic authentication` we need 1 additional row to display the secret's username and password.

  <img width="1639" height="961" alt="Screenshot from 2026-05-18 10-13-29" src="https://github.com/user-attachments/assets/aecea0c6-fca1-452f-94dd-d5bbb5a0f90d" />

  <img width="1639" height="961" alt="Screenshot from 2026-05-18 10-13-48" src="https://github.com/user-attachments/assets/81867738-d1a4-4079-846c-99de3a5a0e7a" />

- Added the CA Bundle secret + tooltip

  <img width="1639" height="961" alt="Screenshot from 2026-05-18 10-14-14" src="https://github.com/user-attachments/assets/de1ce25b-2eca-45d3-b2f1-17c277740a50" />


### Videos


https://github.com/user-attachments/assets/4958c1cf-b607-4637-aa2d-c7da786ee869


