### PR TITLE
Various fixes, ui tools e2e tests

### DIFF
--- a/cypress/e2e/blueprints/pod.ts
+++ b/cypress/e2e/blueprints/pod.ts
@@ -1,0 +1,17 @@
+export const testPod = {
+  apiVersion: 'v1',
+  kind:       'Pod',
+  metadata:   {
+    name:      'test-pod',
+    namespace: 'cattle-ai-agent-system',
+    labels:    {}
+  },
+  spec: {
+    containers: [
+      {
+        name:  'container-0',
+        image: 'nginx'
+      }
+    ]
+  }
+};

--- a/cypress/e2e/po/components/list-options.po.ts
+++ b/cypress/e2e/po/components/list-options.po.ts
@@ -1,0 +1,23 @@
+import ComponentPo from '@rancher/cypress/e2e/po/components/component.po';
+
+export default class ListOptionsPo extends ComponentPo {
+  constructor(index: number) {
+    super(`[data-testid="rancher-ai-ui-chat-message-list-options-${ index }"]`);
+  }
+
+  label() {
+    return this.self().find('.button-group-label');
+  }
+
+  editButton() {
+    return this.self().find('.button-group-action');
+  }
+
+  select() {
+    this.label().click({ force: true });
+  }
+
+  edit() {
+    this.editButton().click({ force: true });
+  }
+}

--- a/cypress/e2e/po/console.po.ts
+++ b/cypress/e2e/po/console.po.ts
@@ -48,4 +48,8 @@ export class ConsolePo extends ComponentPo {
   sendMessage(value: string) {
     this.textarea().type(value).type('{enter}');
   }
+
+  enter() {
+    this.textarea().type('{enter}');
+  }
 }

--- a/cypress/e2e/po/staging/yaml-editor.po.ts
+++ b/cypress/e2e/po/staging/yaml-editor.po.ts
@@ -1,0 +1,39 @@
+import ComponentPo from '@rancher/cypress/e2e/po/components/component.po';
+
+export default class YamlEditorPo extends ComponentPo {
+  constructor() {
+    super('[data-testid="rancher-ai-ui-staging-yaml-editor"]');
+  }
+
+  title() {
+    return this.self().get('[data-testid="rancher-ai-ui-staging-yaml-editor"] .staging-yaml-title');
+  }
+
+  content() {
+    return this.self().get('[data-testid="rancher-ai-ui-staging-yaml-editor-code-mirror"]');
+  }
+
+  closeButton() {
+    return this.self().get('[data-testid="rancher-ai-ui-staging-yaml-editor-close-button"]');
+  }
+
+  cancelButton() {
+    return this.self().get('[data-testid="rancher-ai-ui-staging-yaml-editor-cancel-button"]');
+  }
+
+  confirmButton() {
+    return this.self().get('[data-testid="rancher-ai-ui-staging-yaml-editor-apply-button"]');
+  }
+
+  confirm() {
+    this.confirmButton().click();
+  }
+
+  cancel() {
+    this.cancelButton().click();
+  }
+
+  close() {
+    this.closeButton().click();
+  }
+}

--- a/cypress/e2e/po/staging/yaml-editor.po.ts
+++ b/cypress/e2e/po/staging/yaml-editor.po.ts
@@ -10,7 +10,7 @@ export default class YamlEditorPo extends ComponentPo {
   }
 
   content() {
-    return this.self().get('[data-testid="rancher-ai-ui-staging-yaml-editor-code-mirror"]');
+    return this.self().get('[data-testid="rancher-ai-ui-staging-yaml-editor-code-mirror-editor"]');
   }
 
   closeButton() {

--- a/cypress/e2e/po/ui-tools/tool.po.ts
+++ b/cypress/e2e/po/ui-tools/tool.po.ts
@@ -1,12 +1,13 @@
 import ComponentPo from '@rancher/cypress/e2e/po/components/component.po';
+import ListOptionsPo from '@/cypress/e2e/po/components/list-options.po';
 
 export default class ToolPo extends ComponentPo {
   suggestions(index: number) {
-    return this.self().get(`[data-testid="rancher-ai-ui-chat-message-list-option-${ index }"]`);
+    return new ListOptionsPo(index);
   }
 
   selectOption(index: number) {
-    return this.self().get(`[data-testid="rancher-ai-ui-chat-message-list-option-${ index }"]`);
+    return new ListOptionsPo(index);
   }
 
   explore(route: string) {

--- a/cypress/e2e/tests/features/chat.spec.ts
+++ b/cypress/e2e/tests/features/chat.spec.ts
@@ -10,6 +10,7 @@ import { SettingsPagePo } from '@/cypress/e2e/po/settings.po';
 import ChatPo from '@/cypress/e2e/po/chat.po';
 import { HistoryPo } from '@/cypress/e2e/po/history.po';
 import { SlidingBadgePo } from '@/cypress/e2e/po/hook.po';
+import ContextPo from '@/cypress/e2e/po/context.po';
 import ApplySettingsPromptPo from '@/cypress/e2e/po/dialog/apply-settings.po';
 import { rancherAgentConfig, fleetAgentConfig, provisioningAgentConfig } from '@/cypress/e2e/blueprints/aiAgentConfigs';
 
@@ -457,6 +458,54 @@ describe('Chat', () => {
       chat.getMessage(3).timestamp().should('be.visible');
 
       chat.scrollButton().checkNotExists();
+    });
+
+    it('it should automatically scroll to bottom when receiving a confirmation message', () => {
+      HomePagePo.goTo();
+
+      chat.open();
+      chat.isReady();
+
+      const welcomeMessage = chat.getMessage(1);
+
+      welcomeMessage.isCompleted();
+
+      cy.enqueueLLMResponse({
+        text:      'Pod creation confirmed.',
+        mcpTool: {
+          name: 'createKubernetesResource',
+          args: {
+            kind:      'Pod',
+            name:      'my-pod',
+            resource:  {
+              apiVersion: 'v1',
+              kind:       'Pod',
+              metadata:   {
+                name:      'my-pod',
+                namespace: 'default'
+              },
+            },
+            cluster:   'local',
+            namespace: 'default'
+          }
+        },
+      });
+
+      chat.sendMessage('Create a pod named my-pod in default namespace');
+
+      const userMessage = chat.getMessage(2);
+
+      userMessage.containsText('Create a pod named my-pod in default namespace');
+
+      // Verify the processing label is visible and not covered by the console panel
+      chat.phase('Awaiting confirmation').then(($phase) => {
+        new ContextPo().self().then(($context) => {
+          const phaseRect = $phase[0].getBoundingClientRect();
+          const contextRect = $context[0].getBoundingClientRect();
+
+          expect(contextRect.top + 2).to.be.greaterThan(phaseRect.top);
+        });
+      });
     });
 
     it('it should not scroll to bottom when message stream is in progress and user scrolls up', () => {

--- a/cypress/e2e/tests/features/chat.spec.ts
+++ b/cypress/e2e/tests/features/chat.spec.ts
@@ -536,6 +536,40 @@ describe('Chat', () => {
       chat.scrollButton().checkNotExists();
     });
 
+    it('It should automatically scroll to bottom when close and reopen the chat panel', () => {
+      HomePagePo.goTo();
+
+      chat.open();
+
+      const welcomeMessage = chat.getMessage(1);
+
+      welcomeMessage.isCompleted();
+
+      // Send multiple messages to expand the chat
+      for (let i = 0; i < 2; i++) {
+        chat.sendMessage(`Request ${ i + 1 }`);
+
+        const responseMessage = chat.getMessage(3 + (i * 2));
+
+        responseMessage.isCompleted();
+      }
+
+      // Verify that the request message is not visible and the last message is visible, meaning that the chat has scrolled to the bottom
+      chat.getMessage(2).self().should('not.be.visible');
+      chat.getMessage(5).self().should('be.visible');
+
+      chat.scrollButton().checkNotExists();
+
+      chat.close();
+      chat.open();
+
+      // Verify that the chat has scrolled to the bottom after reopening and the last message is visible
+      chat.getMessage(2).self().should('not.be.visible');
+      chat.getMessage(5).self().should('be.visible');
+
+      chat.scrollButton().checkNotExists();
+    });
+
     it('it should scroll to bottom when clicking the scroll button', () => {
       HomePagePo.goTo();
 

--- a/cypress/e2e/tests/features/chat.spec.ts
+++ b/cypress/e2e/tests/features/chat.spec.ts
@@ -433,7 +433,8 @@ describe('Chat', () => {
       responseMessage.isCompleted();
 
       // Wait for the UI tools to be rendered
-      chat.getMessage(3).tool().suggestions(0).should('exist');
+      chat.getMessage(3).tool().suggestions(0).self()
+        .should('exist');
 
       // Verify that the Request message is not visible and the last message is visible, meaning that the chat has scrolled to the bottom during the stream
       chat.getMessage(2).self().should('not.be.visible');

--- a/cypress/e2e/tests/features/chat.spec.ts
+++ b/cypress/e2e/tests/features/chat.spec.ts
@@ -585,7 +585,7 @@ describe('Chat', () => {
       chat.scrollButton().checkNotExists();
     });
 
-    it('It should automatically scroll to bottom when close and reopen the chat panel', () => {
+    it('it should automatically scroll to bottom when close and reopen the chat panel', () => {
       HomePagePo.goTo();
 
       chat.open();

--- a/cypress/e2e/tests/features/history/message.spec.ts
+++ b/cypress/e2e/tests/features/history/message.spec.ts
@@ -10,6 +10,7 @@ describe('History Messages', () => {
   before(() => {
     cy.login();
     cy.cleanChatHistory();
+    cy.installUIToolsDefinition();
   });
 
   beforeEach(() => {
@@ -53,6 +54,41 @@ describe('History Messages', () => {
           namespace: 'cattle-ai-agent-system'
         }
       },
+      uiTools: [
+        {
+          name: 'suggestions',
+          args: {
+            suggestion1: 'Show me the resources in local cluster',
+            suggestion2: 'Find my deployments',
+            suggestion3: 'Analyze the health status of my clusters',
+          }
+        },
+        {
+          name: 'explore',
+          args: {
+            route:   'pods',
+            cluster: 'local',
+            label:   'View Pods'
+          }
+        },
+        {
+          name: 'explore',
+          args: {
+            route:   'clusters',
+            label:   'View Clusters'
+          }
+        },
+        {
+          name: 'show-yaml',
+          args: {
+            yaml:              'apiVersion: v1\nkind: Pod\nmetadata:\n  name: test-pod\n  namespace: default\nspec:\n  containers:\n  - name: test-container\n    image: nginx:stable-alpine3.20-perl\n',
+            resourceKind:      'pod',
+            resourceName:      'test-pod',
+            resourceNamespace: 'default',
+            title:             'Pod YAML'
+          }
+        }
+      ]
     });
 
     chat.sendMessage('Request message.');
@@ -191,6 +227,25 @@ describe('History Messages', () => {
     historyResponseMessage.sourceLink(0).should('contain.text', 'Why Rancher');
     historyResponseMessage.sourceLink(1).should('contain.text', 'Support');
 
+    // Verify UI tools
+    historyResponseMessage.tool().suggestions(0).self().scrollIntoView()
+      .should('be.visible')
+      .and('contain.text', 'Show me the resources in local cluster');
+    historyResponseMessage.tool().suggestions(1).self().scrollIntoView()
+      .should('be.visible')
+      .and('contain.text', 'Find my deployments');
+    historyResponseMessage.tool().suggestions(2).self().scrollIntoView()
+      .should('be.visible')
+      .and('contain.text', 'Analyze the health status of my clusters');
+    historyResponseMessage.tool().explore('pods').scrollIntoView().should('be.visible')
+      .and('contain.text', 'View Pods');
+    historyResponseMessage.tool().explore('clusters').scrollIntoView().should('be.visible')
+      .and('contain.text', 'View Clusters');
+    historyResponseMessage.tool().showYaml('pod', 'default', 'test-pod')
+      .scrollIntoView()
+      .should('be.visible')
+      .and('contain.text', 'test-pod');
+
     // Verify confirmation action
     let historyUserMessage = chat.getMessage(3);
 
@@ -228,5 +283,6 @@ describe('History Messages', () => {
   after(() => {
     cy.login();
     cy.cleanChatHistory();
+    cy.uninstallUIToolsDefinition();
   });
 });

--- a/cypress/e2e/tests/features/message.spec.ts
+++ b/cypress/e2e/tests/features/message.spec.ts
@@ -43,7 +43,7 @@ describe('Messages', () => {
     const suggestions = ['View resources', 'Analyze logs', 'Do action'];
 
     suggestions.forEach((value, index) => {
-      welcomeMessage.tool().suggestions(index).should('contain.text', value);
+      welcomeMessage.tool().suggestions(index).label().should('contain.text', value);
     });
   });
 

--- a/cypress/e2e/tests/features/ui-tools.spec.ts
+++ b/cypress/e2e/tests/features/ui-tools.spec.ts
@@ -447,6 +447,15 @@ describe('UI Tools', () => {
         yamlEditor.title().should('contain.text', 'Pod YAML');
         yamlEditor.title().should('contain.text', 'default/test-pod');
 
+        // Edit mode buttons should not be visible
+        yamlEditor.content().should('not.contain.text', 'Unified')
+          .and('not.contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'kind: Pod')
+          .and('contain.text', 'name: test-pod')
+          .and('contain.text', 'namespace: default');
+
         yamlEditor.confirmButton().should('not.exist');
         yamlEditor.cancelButton().should('not.exist');
 
@@ -493,6 +502,15 @@ describe('UI Tools', () => {
 
         yamlEditor.title().should('contain.text', 'Pod');
         yamlEditor.title().should('contain.text', 'default/my-pod');
+
+        // Edit mode buttons should not be visible
+        yamlEditor.content().should('not.contain.text', 'Unified')
+          .and('not.contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'kind: Pod')
+          .and('contain.text', 'name: my-pod')
+          .and('contain.text', 'namespace: default');
 
         yamlEditor.confirm();
 
@@ -550,6 +568,15 @@ describe('UI Tools', () => {
         yamlEditor.title().should('contain.text', 'Pod');
         yamlEditor.title().should('contain.text', 'default/my-pod');
 
+        // Edit mode buttons should not be visible
+        yamlEditor.content().should('not.contain.text', 'Unified')
+          .and('not.contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'kind: Pod')
+          .and('contain.text', 'name: my-pod')
+          .and('contain.text', 'namespace: default');
+
         yamlEditor.cancel();
 
         yamlEditor.checkNotExists();
@@ -601,6 +628,15 @@ describe('UI Tools', () => {
 
         yamlEditor.title().should('contain.text', 'Pod');
         yamlEditor.title().should('contain.text', 'default/my-pod');
+
+        // Edit mode buttons should not be visible
+        yamlEditor.content().should('not.contain.text', 'Unified')
+          .and('not.contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'kind: Pod')
+          .and('contain.text', 'name: my-pod')
+          .and('contain.text', 'namespace: default');
 
         confirmationRequestMessage.confirmButton().click();
 
@@ -657,6 +693,15 @@ describe('UI Tools', () => {
 
         yamlEditor.title().should('contain.text', 'Pod');
         yamlEditor.title().should('contain.text', 'default/my-pod');
+
+        // Edit mode buttons should not be visible
+        yamlEditor.content().should('not.contain.text', 'Unified')
+          .and('not.contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'kind: Pod')
+          .and('contain.text', 'name: my-pod')
+          .and('contain.text', 'namespace: default');
 
         confirmationRequestMessage.cancelButton().click();
 
@@ -716,6 +761,14 @@ describe('UI Tools', () => {
         yamlEditor.title().should('contain.text', 'Show Yaml Diff');
         yamlEditor.title().should('contain.text', 'default/test-pod');
 
+        // Edit mode buttons should be visible
+        yamlEditor.content().should('contain.text', 'Unified')
+          .and('contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'labels:')
+          .and('contain.text', 'test:');
+
         yamlEditor.confirmButton().should('not.exist');
         yamlEditor.cancelButton().should('not.exist');
 
@@ -762,6 +815,14 @@ describe('UI Tools', () => {
         yamlEditor.title().should('contain.text', 'Pod');
         yamlEditor.title().should('contain.text', 'cattle-ai-agent-system/test-pod');
 
+        // Edit mode buttons should be visible
+        yamlEditor.content().should('contain.text', 'Unified')
+          .and('contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'labels:')
+          .and('contain.text', 'test:');
+
         yamlEditor.confirm();
 
         yamlEditor.checkNotExists();
@@ -789,7 +850,7 @@ describe('UI Tools', () => {
                 {
                   op:    'add',
                   path:  '/metadata/labels',
-                  value: { test: 'true' }
+                  value: { test1: 'true' }
                 }
               ],
               name:      'test-pod',
@@ -800,11 +861,11 @@ describe('UI Tools', () => {
           },
         });
 
-        chat.sendMessage('Edit test-pod, add the label test=true');
+        chat.sendMessage('Edit test-pod, add the label test1=true');
 
         const userMessage = chat.getMessage(2);
 
-        userMessage.containsText('Edit test-pod, add the label test=true');
+        userMessage.containsText('Edit test-pod, add the label test1=true');
 
         const confirmationRequestMessage = chat.getMessage(3);
 
@@ -816,6 +877,14 @@ describe('UI Tools', () => {
 
         yamlEditor.title().should('contain.text', 'Pod');
         yamlEditor.title().should('contain.text', 'cattle-ai-agent-system/test-pod');
+
+        // Edit mode buttons should be visible
+        yamlEditor.content().should('contain.text', 'Unified')
+          .and('contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'labels:')
+          .and('contain.text', 'test1:');
 
         yamlEditor.cancel();
 
@@ -840,7 +909,7 @@ describe('UI Tools', () => {
                 {
                   op:    'add',
                   path:  '/metadata/labels',
-                  value: { test: 'true' }
+                  value: { test2: 'true' }
                 }
               ],
               name:      'test-pod',
@@ -851,11 +920,11 @@ describe('UI Tools', () => {
           },
         });
 
-        chat.sendMessage('Edit test-pod, add the label test=true');
+        chat.sendMessage('Edit test-pod, add the label test2=true');
 
         const userMessage = chat.getMessage(2);
 
-        userMessage.containsText('Edit test-pod, add the label test=true');
+        userMessage.containsText('Edit test-pod, add the label test2=true');
 
         const confirmationRequestMessage = chat.getMessage(3);
 
@@ -867,6 +936,14 @@ describe('UI Tools', () => {
 
         yamlEditor.title().should('contain.text', 'Pod');
         yamlEditor.title().should('contain.text', 'cattle-ai-agent-system/test-pod');
+
+        // Edit mode buttons should be visible
+        yamlEditor.content().should('contain.text', 'Unified')
+          .and('contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'labels:')
+          .and('contain.text', 'test2:');
 
         confirmationRequestMessage.confirmButton().click({ force: true });
 
@@ -895,7 +972,7 @@ describe('UI Tools', () => {
                 {
                   op:    'add',
                   path:  '/metadata/labels',
-                  value: { test: 'true' }
+                  value: { test3: 'true' }
                 }
               ],
               name:      'test-pod',
@@ -906,11 +983,11 @@ describe('UI Tools', () => {
           },
         });
 
-        chat.sendMessage('Edit test-pod, add the label test=true');
+        chat.sendMessage('Edit test-pod, add the label test3=true');
 
         const userMessage = chat.getMessage(2);
 
-        userMessage.containsText('Edit test-pod, add the label test=true');
+        userMessage.containsText('Edit test-pod, add the label test3=true');
 
         const confirmationRequestMessage = chat.getMessage(3);
 
@@ -922,6 +999,15 @@ describe('UI Tools', () => {
 
         yamlEditor.title().should('contain.text', 'Pod');
         yamlEditor.title().should('contain.text', 'cattle-ai-agent-system/test-pod');
+
+        // Edit mode buttons should be visible
+        yamlEditor.content().should('contain.text', 'Unified')
+          .and('contain.text', 'Split');
+
+        yamlEditor.content()
+          .should('contain.text', 'labels:')
+          .and('contain.text', 'test2:') // Old label
+          .and('contain.text', 'test3:');
 
         confirmationRequestMessage.cancelButton().click({ force: true });
 

--- a/cypress/e2e/tests/features/ui-tools.spec.ts
+++ b/cypress/e2e/tests/features/ui-tools.spec.ts
@@ -1,8 +1,13 @@
+import ClusterManagerListPagePo from '@rancher/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import { WorkloadsPodsListPagePo } from '@rancher/cypress/e2e/po/pages/explorer/workloads-pods.po';
+import { WorkloadsDeploymentsListPagePo } from '@rancher/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po';
 import HomePagePo from '@rancher/cypress/e2e/po/pages/home.po';
 
 import ChatPo from '@/cypress/e2e/po/chat.po';
 import RequiredActionPo from '@/cypress/e2e/po/ui-tools/required-action.po';
 import { SettingsPagePo } from '@/cypress/e2e/po/settings.po';
+import YamlEditorPo from '@/cypress/e2e/po/staging/yaml-editor.po';
+import { testPod } from '@/cypress/e2e/blueprints/pod';
 
 describe('UI Tools', () => {
   const chat = new ChatPo();
@@ -153,16 +158,20 @@ describe('UI Tools', () => {
     });
   });
 
-  describe('Tool: suggestions', () => {
+  describe('Widgets', () => {
+    const deploymentsListPage = new WorkloadsDeploymentsListPagePo('local', 'apps.deployment' as any);
+
     before(() => {
       cy.login();
       cy.installUIToolsDefinition();
+      cy.cleanChatHistory();
     });
 
     beforeEach(() => {
       cy.login();
+      cy.clearLLMResponses();
 
-      HomePagePo.goTo();
+      deploymentsListPage.goTo();
 
       chat.open();
 
@@ -171,56 +180,769 @@ describe('UI Tools', () => {
       welcomeMessage.isCompleted();
     });
 
-    it('Show the list of suggestions', () => {
-      cy.enqueueLLMResponse({
-        text:      ['Here', ' are the suggestions.'],
-        uiTools:   [
-          {
-            name: 'suggestions',
-            args: {
-              suggestion1: 'Show me the resources',
-              suggestion2: 'The list of clusters',
-              suggestion3: 'Another suggestion',
+    describe('suggestions', () => {
+      it('it shows the list of suggestions and send/edit one suggestion', () => {
+        cy.enqueueLLMResponse({
+          text:      ['Here', ' are the suggestions.'],
+          uiTools:   [
+            {
+              name: 'suggestions',
+              args: {
+                suggestion1: 'Show me the resources',
+                suggestion2: 'The list of clusters',
+                suggestion3: 'Another suggestion',
+              }
             }
-          }
-        ]
+          ]
+        });
+
+        chat.sendMessage('Show me the suggestions');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Show me the suggestions');
+
+        const resultMessage = chat.getMessage(3);
+
+        resultMessage.isCompleted();
+
+        resultMessage.tool().suggestions(0).label()
+          .should('be.visible')
+          .and('contain.text', 'Show me the resources');
+        resultMessage.tool().suggestions(1).label()
+          .should('be.visible')
+          .and('contain.text', 'The list of clusters');
+        resultMessage.tool().suggestions(2).label()
+          .should('be.visible')
+          .and('contain.text', 'Another suggestion');
+
+        // Send the second suggestion
+        resultMessage.tool().suggestions(1).select();
+
+        chat.getMessage(4).containsText('The list of clusters');
+
+        chat.getMessage(5).isCompleted();
+
+        // Edit the third suggestion and send
+        resultMessage.tool().suggestions(2).edit();
+
+        chat.console().enter();
+
+        chat.getMessage(6).containsText('Another suggestion');
+
+        chat.getMessage(7).isCompleted();
       });
 
-      chat.sendMessage('Show me the suggestions');
+      it('it should not show suggestions when select-option tool is present', () => {
+        cy.enqueueLLMResponse({
+          text:      ['Here', ' are the suggestions.'],
+          uiTools:   [
+            {
+              name: 'suggestions',
+              args: {
+                suggestion1: 'Show me the resources',
+                suggestion2: 'The list of clusters',
+                suggestion3: 'Another suggestion',
+              }
+            },
+            {
+              name: 'select-option',
+              args: {
+                option1: 'Deployment',
+                option2: 'Pod',
+                option3: 'Service',
+              }
+            }
+          ]
+        });
 
-      const userMessage = chat.getMessage(2);
+        chat.sendMessage('Show me the tools');
 
-      userMessage.scrollIntoView();
-      userMessage.containsText('Show me the suggestions');
+        const userMessage = chat.getMessage(2);
 
-      const resultMessage = chat.getMessage(3);
+        userMessage.containsText('Show me the tools');
 
-      resultMessage.tool().suggestions(0).scrollIntoView().should('be.visible')
-        .and('contain.text', 'Show me the resources');
-      resultMessage.tool().suggestions(1).scrollIntoView().should('be.visible')
-        .and('contain.text', 'The list of clusters');
-      resultMessage.tool().suggestions(2).scrollIntoView().should('be.visible')
-        .and('contain.text', 'Another suggestion');
+        const resultMessage = chat.getMessage(3);
 
-      // TODO: add check for edit mode and send message on click
+        resultMessage.isCompleted();
+
+        resultMessage.tool().suggestions(0).self().should('not.exist');
+        resultMessage.tool().suggestions(1).self().should('not.exist');
+        resultMessage.tool().suggestions(2).self().should('not.exist');
+      });
+    });
+
+    describe('select-option', () => {
+      it('it should show the list of options and select one option', () => {
+        cy.enqueueLLMResponse({
+          text:      ['Select an option from the list below.'],
+          uiTools:   [
+            {
+              name: 'select-option',
+              args: {
+                option1: 'Deployment',
+                option2: 'Pod',
+                option3: 'Service',
+              }
+            }
+          ]
+        });
+
+        chat.sendMessage('Show me the options');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Show me the options');
+
+        const resultMessage = chat.getMessage(3);
+
+        resultMessage.isCompleted();
+
+        resultMessage.tool().selectOption(0).label()
+          .should('be.visible')
+          .and('contain.text', 'Deployment');
+        resultMessage.tool().selectOption(1).label()
+          .should('be.visible')
+          .and('contain.text', 'Pod');
+        resultMessage.tool().selectOption(2).label()
+          .should('be.visible')
+          .and('contain.text', 'Service');
+
+        // Select the first option
+        resultMessage.tool().selectOption(0).select();
+
+        chat.getMessage(4).containsText('Deployment');
+      });
+    });
+
+    describe('explore', () => {
+      it('it should show the explore button and navigate to the correct page when clicking on it', () => {
+        cy.enqueueLLMResponse({
+          text:      ['Navigate to Rancher using the buttons below.'],
+          uiTools:   [
+            {
+              name: 'explore',
+              args: {
+                route:   'pods',
+                cluster: 'local',
+                label:   'View Pods'
+              }
+            },
+            {
+              name: 'explore',
+              args: {
+                route:   'clusters',
+                label:   'View Clusters'
+              }
+            }
+          ]
+        });
+
+        chat.sendMessage('Request to explore');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Request to explore');
+
+        const resultMessage = chat.getMessage(3);
+
+        resultMessage.isCompleted();
+
+        const explorePods = resultMessage.tool().explore('pods');
+
+        explorePods.click();
+
+        const workloadsPodPage = new WorkloadsPodsListPagePo('local');
+
+        workloadsPodPage.waitForPage();
+
+        const exploreClusters = resultMessage.tool().explore('clusters');
+
+        exploreClusters.click();
+
+        const clustersPage = new ClusterManagerListPagePo('_');
+
+        clustersPage.waitForPage();
+      });
+    });
+
+    describe('open-console-logs', () => {
+      it('it should open the console logs with correct parameters', () => {
+        cy.createRancherResource('v1', 'pods', JSON.stringify(testPod), false);
+
+        cy.enqueueLLMResponse({
+          text:      ['Check the console logs using the button below.'],
+          uiTools:   [
+            {
+              name: 'open-console-logs',
+              args: {
+                cluster:       'local',
+                namespace:     testPod.metadata.namespace,
+                name:          testPod.metadata.name,
+                containerName: testPod.spec.containers[0].name,
+              }
+            }
+          ]
+        });
+
+        chat.sendMessage('Show me the logs');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Show me the logs');
+
+        const resultMessage = chat.getMessage(3);
+
+        resultMessage.isCompleted();
+
+        const showLogs = resultMessage.tool().openConsoleLogs('local', testPod.metadata.namespace, testPod.metadata.name, testPod.spec.containers[0].name);
+
+        showLogs.click();
+
+        cy.get(`[data-testid="horizontal-window-manager"]`).should('contain.text', testPod.metadata.name);
+
+        cy.deleteRancherResource('v1', 'pods', `${ testPod.metadata.namespace }/${ testPod.metadata.name }`, false);
+      });
+    });
+
+    describe('show-yaml', () => {
+      it('it should show the yaml content in the YAML editor', () => {
+        cy.enqueueLLMResponse({
+          text:      ['See the YAML content using the button below.'],
+          uiTools:   [
+            {
+              name: 'show-yaml',
+              args: {
+                yaml:              'apiVersion: v1\nkind: Pod\nmetadata:\n  name: test-pod\n  namespace: default\nspec:\n  containers:\n  - name: test-container\n    image: nginx:stable-alpine3.20-perl\n',
+                resourceKind:      'pod',
+                resourceName:      'test-pod',
+                resourceNamespace: 'default',
+                title:             'Pod YAML'
+              }
+            }
+          ]
+        });
+
+        chat.sendMessage('Show me the YAML');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Show me the YAML');
+
+        const resultMessage = chat.getMessage(3);
+
+        resultMessage.isCompleted();
+
+        const showYaml = resultMessage.tool().showYaml('pod', 'default', 'test-pod');
+
+        showYaml.click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Pod YAML');
+        yamlEditor.title().should('contain.text', 'default/test-pod');
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+
+        yamlEditor.close();
+
+        yamlEditor.checkNotExists();
+      });
+
+      it('it should confirm changes when clicking on the confirm button in the YAML editor', () => {
+        cy.enqueueLLMResponse({
+          text:      'Pod creation confirmed.',
+          mcpTool: {
+            name: 'createKubernetesResource',
+            args: {
+              kind:      'Pod',
+              name:      'my-pod',
+              resource:  {
+                apiVersion: 'v1',
+                kind:       'Pod',
+                metadata:   {
+                  name:      'my-pod',
+                  namespace: 'default'
+                },
+              },
+              cluster:   'local',
+              namespace: 'default'
+            }
+          },
+        });
+
+        chat.sendMessage('Create a pod named my-pod in default namespace');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Create a pod named my-pod in default namespace');
+
+        const confirmationRequestMessage = chat.getMessage(3);
+
+        confirmationRequestMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYaml('Pod', 'default', 'my-pod').click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Pod');
+        yamlEditor.title().should('contain.text', 'default/my-pod');
+
+        yamlEditor.confirm();
+
+        yamlEditor.checkNotExists();
+
+        confirmationRequestMessage.isConfirmed();
+        confirmationRequestMessage.containsText('Confirmed');
+
+        const confirmationResponseMessage = chat.getMessage(4);
+
+        confirmationResponseMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYaml('Pod', 'default', 'my-pod').click();
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+      });
+
+      it('it should discard changes when clicking on the cancel button in the YAML editor', () => {
+        cy.enqueueLLMResponse({
+          text:      'Pod creation canceled.',
+          mcpTool: {
+            name: 'createKubernetesResource',
+            args: {
+              kind:      'Pod',
+              name:      'my-pod',
+              resource:  {
+                apiVersion: 'v1',
+                kind:       'Pod',
+                metadata:   {
+                  name:      'my-pod',
+                  namespace: 'default'
+                },
+              },
+              cluster:   'local',
+              namespace: 'default'
+            }
+          },
+        });
+
+        chat.sendMessage('Create a pod named my-pod in default namespace');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Create a pod named my-pod in default namespace');
+
+        const confirmationRequestMessage = chat.getMessage(3);
+
+        confirmationRequestMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYaml('Pod', 'default', 'my-pod').click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Pod');
+        yamlEditor.title().should('contain.text', 'default/my-pod');
+
+        yamlEditor.cancel();
+
+        yamlEditor.checkNotExists();
+
+        confirmationRequestMessage.isCanceled();
+        confirmationRequestMessage.containsText('Canceled');
+
+        confirmationRequestMessage.tool().showYaml('Pod', 'default', 'my-pod').click();
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+      });
+
+      it('it should close the editor when confirm a confirmation request in the Chat', () => {
+        cy.enqueueLLMResponse({
+          text:      'Pod creation confirmed.',
+          mcpTool: {
+            name: 'createKubernetesResource',
+            args: {
+              kind:      'Pod',
+              name:      'my-pod',
+              resource:  {
+                apiVersion: 'v1',
+                kind:       'Pod',
+                metadata:   {
+                  name:      'my-pod',
+                  namespace: 'default'
+                },
+              },
+              cluster:   'local',
+              namespace: 'default'
+            }
+          },
+        });
+
+        chat.sendMessage('Create a pod named my-pod in default namespace');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Create a pod named my-pod in default namespace');
+
+        const confirmationRequestMessage = chat.getMessage(3);
+
+        confirmationRequestMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYaml('Pod', 'default', 'my-pod').click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Pod');
+        yamlEditor.title().should('contain.text', 'default/my-pod');
+
+        confirmationRequestMessage.confirmButton().click();
+
+        yamlEditor.checkNotExists();
+
+        confirmationRequestMessage.isConfirmed();
+        confirmationRequestMessage.containsText('Confirmed');
+
+        const confirmationResponseMessage = chat.getMessage(4);
+
+        confirmationResponseMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYaml('Pod', 'default', 'my-pod').click();
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+      });
+
+      it('it should close the editor when cancel a confirmation request in the Chat', () => {
+        cy.enqueueLLMResponse({
+          text:      'Pod creation canceled.',
+          mcpTool: {
+            name: 'createKubernetesResource',
+            args: {
+              kind:      'Pod',
+              name:      'my-pod',
+              resource:  {
+                apiVersion: 'v1',
+                kind:       'Pod',
+                metadata:   {
+                  name:      'my-pod',
+                  namespace: 'default'
+                },
+              },
+              cluster:   'local',
+              namespace: 'default'
+            }
+          },
+        });
+
+        chat.sendMessage('Create a pod named my-pod in default namespace');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Create a pod named my-pod in default namespace');
+
+        const confirmationRequestMessage = chat.getMessage(3);
+
+        confirmationRequestMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYaml('Pod', 'default', 'my-pod').click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Pod');
+        yamlEditor.title().should('contain.text', 'default/my-pod');
+
+        confirmationRequestMessage.cancelButton().click();
+
+        yamlEditor.checkNotExists();
+
+        confirmationRequestMessage.isCanceled();
+        confirmationRequestMessage.containsText('Canceled');
+
+        confirmationRequestMessage.tool().showYaml('Pod', 'default', 'my-pod').click();
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+      });
+    });
+
+    describe('show-yaml-diff', () => {
+      before(() => {
+        cy.login();
+        cy.createRancherResource('v1', 'pods', JSON.stringify(testPod), false);
+      });
+
+      it('it should show the yaml diff in the YAML editor', () => {
+        cy.enqueueLLMResponse({
+          text:      ['See the YAML content using the button below.'],
+          uiTools:   [
+            {
+              name: 'show-yaml-diff',
+              args: {
+                original:          'apiVersion: v1\nkind: Pod\nmetadata:\n  name: test-pod\n  namespace: default\nspec:\n  containers:\n  - name: test-container\n    image: nginx:stable-alpine3.20-perl\n',
+                // Same of original + test label
+                patched:           'apiVersion: v1\nkind: Pod\nmetadata:\n  name: test-pod\n  namespace: default\n  labels:\n    test: "true"\nspec:\n  containers:\n  - name: test-container\n    image: nginx:stable-alpine3.20-perl\n',
+                resourceKind:      'pod',
+                resourceName:      'test-pod',
+                resourceNamespace: 'default',
+                title:             'Show Yaml Diff'
+              }
+            }
+          ]
+        });
+
+        chat.sendMessage('Show me the YAML diff');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Show me the YAML diff');
+
+        const resultMessage = chat.getMessage(3);
+
+        resultMessage.isCompleted();
+
+        const showYamlDiff = resultMessage.tool().showYamlDiff('pod', 'default', 'test-pod');
+
+        showYamlDiff.click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Show Yaml Diff');
+        yamlEditor.title().should('contain.text', 'default/test-pod');
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+
+        yamlEditor.close();
+
+        yamlEditor.checkNotExists();
+      });
+
+      it('it should confirm changes when clicking on the confirm button in the YAML editor', () => {
+        cy.enqueueLLMResponse({
+          text:      'Pod patch confirmed.',
+          mcpTool: {
+            name: 'patchKubernetesResource',
+            args: {
+              patch: [
+                {
+                  op:    'add',
+                  path:  '/metadata/labels',
+                  value: { test: 'true' }
+                }
+              ],
+              name:      'test-pod',
+              kind:      'Pod',
+              cluster:   'local',
+              namespace: 'cattle-ai-agent-system'
+            }
+          },
+        });
+
+        chat.sendMessage('Edit test-pod, add the label test=true');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Edit test-pod, add the label test=true');
+
+        const confirmationRequestMessage = chat.getMessage(3);
+
+        confirmationRequestMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYamlDiff('Pod', 'cattle-ai-agent-system', 'test-pod').click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Pod');
+        yamlEditor.title().should('contain.text', 'cattle-ai-agent-system/test-pod');
+
+        yamlEditor.confirm();
+
+        yamlEditor.checkNotExists();
+
+        confirmationRequestMessage.isConfirmed();
+        confirmationRequestMessage.containsText('Confirmed');
+
+        const confirmationResponseMessage = chat.getMessage(4);
+
+        confirmationResponseMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYamlDiff('Pod', 'cattle-ai-agent-system', 'test-pod').click();
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+      });
+
+      it('it should discard changes when clicking on the cancel button in the YAML editor', () => {
+        cy.enqueueLLMResponse({
+          text:      'Pod patch canceled.',
+          mcpTool: {
+            name: 'patchKubernetesResource',
+            args: {
+              patch: [
+                {
+                  op:    'add',
+                  path:  '/metadata/labels',
+                  value: { test: 'true' }
+                }
+              ],
+              name:      'test-pod',
+              kind:      'Pod',
+              cluster:   'local',
+              namespace: 'cattle-ai-agent-system'
+            }
+          },
+        });
+
+        chat.sendMessage('Edit test-pod, add the label test=true');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Edit test-pod, add the label test=true');
+
+        const confirmationRequestMessage = chat.getMessage(3);
+
+        confirmationRequestMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYamlDiff('Pod', 'cattle-ai-agent-system', 'test-pod').click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Pod');
+        yamlEditor.title().should('contain.text', 'cattle-ai-agent-system/test-pod');
+
+        yamlEditor.cancel();
+
+        yamlEditor.checkNotExists();
+
+        confirmationRequestMessage.isCanceled();
+        confirmationRequestMessage.containsText('Canceled');
+
+        confirmationRequestMessage.tool().showYamlDiff('Pod', 'cattle-ai-agent-system', 'test-pod').click();
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+      });
+
+      it('it should close the editor when cancel a confirmation request in the Chat', () => {
+        cy.enqueueLLMResponse({
+          text:      'Pod patch confirmed.',
+          mcpTool: {
+            name: 'patchKubernetesResource',
+            args: {
+              patch: [
+                {
+                  op:    'add',
+                  path:  '/metadata/labels',
+                  value: { test: 'true' }
+                }
+              ],
+              name:      'test-pod',
+              kind:      'Pod',
+              cluster:   'local',
+              namespace: 'cattle-ai-agent-system'
+            }
+          },
+        });
+
+        chat.sendMessage('Edit test-pod, add the label test=true');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Edit test-pod, add the label test=true');
+
+        const confirmationRequestMessage = chat.getMessage(3);
+
+        confirmationRequestMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYamlDiff('Pod', 'cattle-ai-agent-system', 'test-pod').click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Pod');
+        yamlEditor.title().should('contain.text', 'cattle-ai-agent-system/test-pod');
+
+        confirmationRequestMessage.confirmButton().click({ force: true });
+
+        yamlEditor.checkNotExists();
+
+        confirmationRequestMessage.isConfirmed();
+        confirmationRequestMessage.containsText('Confirmed');
+
+        const confirmationResponseMessage = chat.getMessage(4);
+
+        confirmationResponseMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYamlDiff('Pod', 'cattle-ai-agent-system', 'test-pod').click();
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+      });
+
+      it('it should close the editor when confirm a confirmation request in the Chat', () => {
+        cy.enqueueLLMResponse({
+          text:      'Pod patch canceled.',
+          mcpTool: {
+            name: 'patchKubernetesResource',
+            args: {
+              patch: [
+                {
+                  op:    'add',
+                  path:  '/metadata/labels',
+                  value: { test: 'true' }
+                }
+              ],
+              name:      'test-pod',
+              kind:      'Pod',
+              cluster:   'local',
+              namespace: 'cattle-ai-agent-system'
+            }
+          },
+        });
+
+        chat.sendMessage('Edit test-pod, add the label test=true');
+
+        const userMessage = chat.getMessage(2);
+
+        userMessage.containsText('Edit test-pod, add the label test=true');
+
+        const confirmationRequestMessage = chat.getMessage(3);
+
+        confirmationRequestMessage.isCompleted();
+
+        confirmationRequestMessage.tool().showYamlDiff('Pod', 'cattle-ai-agent-system', 'test-pod').click();
+
+        const yamlEditor = new YamlEditorPo();
+
+        yamlEditor.title().should('contain.text', 'Pod');
+        yamlEditor.title().should('contain.text', 'cattle-ai-agent-system/test-pod');
+
+        confirmationRequestMessage.cancelButton().click({ force: true });
+
+        yamlEditor.checkNotExists();
+
+        confirmationRequestMessage.isCanceled();
+        confirmationRequestMessage.containsText('Canceled');
+
+        confirmationRequestMessage.tool().showYamlDiff('Pod', 'cattle-ai-agent-system', 'test-pod').click();
+
+        yamlEditor.confirmButton().should('not.exist');
+        yamlEditor.cancelButton().should('not.exist');
+      });
+
+      after(() => {
+        cy.deleteRancherResource('v1', 'pods', `${ testPod.metadata.namespace }/${ testPod.metadata.name }`, false);
+      });
+    });
+
+    afterEach(() => {
+      cy.clearLLMResponses();
     });
 
     after(() => {
-      cy.clearLLMResponses();
+      cy.cleanChatHistory();
       cy.uninstallUIToolsDefinition();
     });
   });
-
-  /**
-   * TODO
-   *
-   *  - verify multiple tools in the same response
-   *  - verify suggestions vs select-option mutual exclusion
-   *  - add the tests for the staging page (show-yaml, show-yaml-diff)
-   */
-  describe.skip('Tool: select-option', () => {});
-  describe.skip('Tool: explore', () => {});
-  describe.skip('Tool: open-console-logs', () => {});
-  describe.skip('Tool: show-yaml', () => {});
-  describe.skip('Tool: show-yaml-diff', () => {});
 });

--- a/cypress/e2e/tests/features/ui-tools.spec.ts
+++ b/cypress/e2e/tests/features/ui-tools.spec.ts
@@ -367,9 +367,12 @@ describe('UI Tools', () => {
     });
 
     describe('open-console-logs', () => {
-      it('it should open the console logs with correct parameters', () => {
+      before(() => {
+        cy.login();
         cy.createRancherResource('v1', 'pods', JSON.stringify(testPod), false);
+      });
 
+      it('it should open the console logs with correct parameters', () => {
         cy.enqueueLLMResponse({
           text:      ['Check the console logs using the button below.'],
           uiTools:   [
@@ -400,7 +403,9 @@ describe('UI Tools', () => {
         showLogs.click();
 
         cy.get(`[data-testid="horizontal-window-manager"]`).should('contain.text', testPod.metadata.name);
+      });
 
+      after(() => {
         cy.deleteRancherResource('v1', 'pods', `${ testPod.metadata.namespace }/${ testPod.metadata.name }`, false);
       });
     });
@@ -825,7 +830,7 @@ describe('UI Tools', () => {
         yamlEditor.cancelButton().should('not.exist');
       });
 
-      it('it should close the editor when cancel a confirmation request in the Chat', () => {
+      it('it should close the editor when confirm a confirmation request in the Chat', () => {
         cy.enqueueLLMResponse({
           text:      'Pod patch confirmed.',
           mcpTool: {
@@ -880,7 +885,7 @@ describe('UI Tools', () => {
         yamlEditor.cancelButton().should('not.exist');
       });
 
-      it('it should close the editor when confirm a confirmation request in the Chat', () => {
+      it('it should close the editor when cancel a confirmation request in the Chat', () => {
         cy.enqueueLLMResponse({
           text:      'Pod patch canceled.',
           mcpTool: {

--- a/pkg/rancher-ai-ui/components/ListOptions.vue
+++ b/pkg/rancher-ai-ui/components/ListOptions.vue
@@ -60,12 +60,14 @@ const hoveredIndex = ref<number | null>(null);
           @mouseenter="hoveredIndex = index"
           @mouseleave="hoveredIndex = null"
         >
-          <div class="button-group">
+          <div
+            class="button-group"
+            :data-testid="`rancher-ai-ui-chat-message-list-options-${index}`"
+          >
             <RcButton
               class="button-group-label"
               variant="tertiary"
               small
-              :data-testid="`rancher-ai-ui-chat-message-list-option-${index}`"
               @click="props.disabled ? undefined : emit('select', option)"
             >
               <span class="rc-button-label">

--- a/pkg/rancher-ai-ui/components/panels/Console.vue
+++ b/pkg/rancher-ai-ui/components/panels/Console.vue
@@ -163,6 +163,9 @@ function copyUserPreviousMessage(direction: 'prev' | 'next') {
 
 /**
  * Helper to Clear the CompleteText and reset the HistoryIndex, used when sending a message or changing the chat to avoid showing wrong completeText
+ *
+ * It clears the input and handles the textarea resize before emitting the content
+ * to avoid potential flickering in messages view autoscroll
  */
 function clearCompleteTextHistory() {
   completeText.value = '';
@@ -175,13 +178,13 @@ function sendContent(event: Event) {
 
   const content = cleanInput(text.value);
 
-  if (content) {
-    emit('input:content', content);
-  }
-
   clearCompleteTextHistory();
   updateInput('');
-  nextTick(autoResizePrompt);
+  autoResizePrompt();
+
+  if (content) {
+    nextTick(() => emit('input:content', content));
+  }
 }
 
 function selectAgent(agentName: string) {

--- a/pkg/rancher-ai-ui/components/panels/Messages.vue
+++ b/pkg/rancher-ai-ui/components/panels/Messages.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { debounce } from 'lodash';
 import {
   ref, computed, watch, onBeforeUnmount, type PropType, type ComponentPublicInstance
 } from 'vue';
@@ -71,7 +70,7 @@ const containerRef = (count: number, index: number) => {
 };
 
 // Observes changes to the last message container to trigger auto-scrolling when content changes
-const setupObserver = debounce((newContainer: HTMLDivElement | null) => {
+function setupObserver(newContainer: HTMLDivElement | null) {
   // Clean up old observer
   if (lastMessageObserver.value) {
     lastMessageObserver.value.disconnect();
@@ -93,7 +92,7 @@ const setupObserver = debounce((newContainer: HTMLDivElement | null) => {
       characterData: true,
     });
   }
-}, 100);
+}
 
 const {
   fastScrollEnabled,
@@ -173,9 +172,6 @@ watch(
 );
 
 onBeforeUnmount(() => {
-  // Cancel pending debounced calls
-  setupObserver.cancel();
-
   // Cleanup observer
   if (lastMessageObserver.value) {
     lastMessageObserver.value.disconnect();

--- a/pkg/rancher-ai-ui/components/panels/Messages.vue
+++ b/pkg/rancher-ai-ui/components/panels/Messages.vue
@@ -148,7 +148,7 @@ function getMessageTemplate(component: MessageTemplateComponent) {
 watch(
   () => props.activeChatId,
   (newVal, oldVal) => {
-    if (oldVal && newVal !== oldVal) {
+    if (newVal !== oldVal) {
       // Wait for the DOM to update with the new messages before scrolling
       requestAnimationFrame(() => {
         // Update scroll state to show/hide scroll button based on new content height
@@ -156,7 +156,8 @@ watch(
         scrollToBottom({ force: true });
       });
     }
-  }
+  },
+  { immediate: true }
 );
 
 // Scroll when the phase changes

--- a/pkg/rancher-ai-ui/components/tools/index.vue
+++ b/pkg/rancher-ai-ui/components/tools/index.vue
@@ -51,9 +51,10 @@ const tools = computed(() => {
     .filter((tool) => !props.exclude.includes(tool.toolName) &&
       (props.include.length === 0 || props.include.includes(tool.toolName)))
     // Add unique keys to each tool for rendering
-    .map((tool) => ({
+    // Use index if include prop is provided (stable keys), otherwise generate random keys to prevent caching issues when tools change dynamically
+    .map((tool, index) => ({
       ...tool,
-      key: `${ tool.toolName }-${ randomStr(4) }`,
+      key: `${ tool.toolName }-${ props.include.length > 0 ? index : randomStr(4) }`,
     }))
     // Sort tools based on predefined order
     .sort((a, b) => ToolsOrder[a.toolName] - ToolsOrder[b.toolName]);

--- a/pkg/rancher-ai-ui/pages/staging/yaml-editor/index.vue
+++ b/pkg/rancher-ai-ui/pages/staging/yaml-editor/index.vue
@@ -144,7 +144,7 @@ watch(patched, (val) => {
         :initial-yaml-values="original"
         :editor-mode="props.value?.editorMode"
         :scrolling="true"
-        :component-testid="'rancher-ai-ui-staging-yaml-editor'"
+        data-testid="rancher-ai-ui-staging-yaml-editor-code-mirror-editor"
         class="yaml-editor"
       />
     </div>

--- a/pkg/rancher-ai-ui/pages/staging/yaml-editor/index.vue
+++ b/pkg/rancher-ai-ui/pages/staging/yaml-editor/index.vue
@@ -92,7 +92,10 @@ watch(patched, (val) => {
 </script>
 
 <template>
-  <div class="staging-yaml-editor">
+  <div
+    class="staging-yaml-editor"
+    data-testid="rancher-ai-ui-staging-yaml-editor"
+  >
     <div class="staging-yaml-header">
       <div class="staging-yaml-title">
         <h1>{{ props.value?.title || t('ai.staging.yaml-editor.title', {}, true) }}</h1>
@@ -106,12 +109,14 @@ watch(patched, (val) => {
       >
         <RcButton
           variant="secondary"
+          data-testid="rancher-ai-ui-staging-yaml-editor-cancel-button"
           @click="handleCancel"
         >
           {{ t('ai.staging.yaml-editor.cancel', {}, true) }}
         </RcButton>
         <RcButton
           variant="primary"
+          data-testid="rancher-ai-ui-staging-yaml-editor-apply-button"
           @click="handleApply"
         >
           {{ t('ai.staging.yaml-editor.apply', {}, true) }}
@@ -123,6 +128,7 @@ watch(patched, (val) => {
       >
         <RcButton
           variant="secondary"
+          data-testid="rancher-ai-ui-staging-yaml-editor-close-button"
           @click="emit('close')"
         >
           {{ t('ai.staging.yaml-editor.close', {}, true) }}
@@ -138,8 +144,8 @@ watch(patched, (val) => {
         :initial-yaml-values="original"
         :editor-mode="props.value?.editorMode"
         :scrolling="true"
+        :component-testid="'rancher-ai-ui-staging-yaml-editor'"
         class="yaml-editor"
-        data-testid="staging-yaml-editor"
       />
     </div>
   </div>


### PR DESCRIPTION
The ui tools [tests](4aff67727d87d2e14ea6e31a1c0f1c095344423b) found some issues:

- 1a1a5991886f25f5a6f59a9ae5cfc65359eab0c2 : the random key is breaking the references to the props.message in the ShowYaml and ShowYamlDiff. When the list of tools are pre-defined, is safer to use the index as key, otherwise we can continue using the random key

  before - it doesn't close the editor, the ref to the current message status is lost

  https://github.com/user-attachments/assets/af745980-37f1-4875-b67d-fde90f698223

  after - the editor can close

  https://github.com/user-attachments/assets/ffe98583-c86c-4ded-b854-266ea57fd6db

- 2fddd04d80af6df0c8a9e7b246fa869e90b5cee6 : we want to scroll to bottom when opening a previous chat

- 9193e2ce92946b99135010a0fd9d6c83edf346c6 : debounce removed - the 100 ms was breaking the auto scroll when the processing label changes before the last message (Confirmation messages)

  before

    https://github.com/user-attachments/assets/9cdd9ee3-9575-4f69-af49-b922177189b1

  after

   https://github.com/user-attachments/assets/a5a1c130-4008-429b-913b-2410326cb33f




  


  
  
