### PR TITLE
Fix confirmation request 

### DIFF
--- a/cypress/e2e/po/message.po.ts
+++ b/cypress/e2e/po/message.po.ts
@@ -51,7 +51,7 @@ class RawMessagePo extends ComponentPo {
   }
 
   confirmationStatus() {
-    return this.self().get('[data-testid="rancher-ai-ui-chat-message-confirmation-status"]');
+    return this.self().get('[data-testid^="rancher-ai-ui-chat-message-confirmation-status-"]');
   }
 
   isCompleted() {
@@ -59,11 +59,11 @@ class RawMessagePo extends ComponentPo {
   }
 
   isConfirmed(args = { withLabel: 'Confirmed' }) {
-    return this.confirmationStatus().get('.status-confirmed').should('contain.text', args.withLabel);
+    return this.self().get('[data-testid="rancher-ai-ui-chat-message-confirmation-status-confirmed"]').should('contain.text', args.withLabel);
   }
 
   isCanceled(args = { withLabel: 'Canceled' }) {
-    return this.confirmationStatus().get('.status-canceled').should('contain.text', args.withLabel);
+    return this.self().get('[data-testid="rancher-ai-ui-chat-message-confirmation-status-canceled"]').should('contain.text', args.withLabel);
   }
 
   thinkingLabel() {

--- a/cypress/e2e/po/message.po.ts
+++ b/cypress/e2e/po/message.po.ts
@@ -50,16 +50,20 @@ class RawMessagePo extends ComponentPo {
     return this.self().get('[data-testid="rancher-ai-ui-chat-message-confirmation-cancel-button"]');
   }
 
+  confirmationStatus() {
+    return this.self().get('[data-testid="rancher-ai-ui-chat-message-confirmation-status"]');
+  }
+
   isCompleted() {
     return this.self().get(`[data-teststatus="rancher-ai-ui-chat-message-status-${ this.id }-completed"]`).should('exist');
   }
 
-  isConfirmed() {
-    return this.self().get('[data-testid="rancher-ai-ui-chat-message-confirmation-confirmed"]').should('exist');
+  isConfirmed(args = { withLabel: 'Confirmed' }) {
+    return this.confirmationStatus().get('.status-confirmed').should('contain.text', args.withLabel);
   }
 
-  isCanceled() {
-    return this.self().get('[data-testid="rancher-ai-ui-chat-message-confirmation-canceled"]').should('exist');
+  isCanceled(args = { withLabel: 'Canceled' }) {
+    return this.confirmationStatus().get('.status-canceled').should('contain.text', args.withLabel);
   }
 
   thinkingLabel() {

--- a/cypress/e2e/tests/features/history/message.spec.ts
+++ b/cypress/e2e/tests/features/history/message.spec.ts
@@ -138,7 +138,6 @@ describe('History Messages', () => {
     confirmationRequestMessage.containsText('Are you sure you want to proceed with this action?');
     confirmationRequestMessage.confirmButton().click();
     confirmationRequestMessage.isConfirmed();
-    confirmationRequestMessage.containsText('Confirmed');
 
     const resultMessage = chat.getMessage(6);
 
@@ -266,8 +265,7 @@ describe('History Messages', () => {
     historyConfirmedMessage.scrollIntoView();
     historyConfirmedMessage.confirmButton().should('not.exist');
     historyConfirmedMessage.cancelButton().should('not.exist');
-    historyConfirmedMessage.isConfirmed().scrollIntoView();
-    historyConfirmedMessage.containsText('Confirmed');
+    historyConfirmedMessage.isConfirmed();
 
     const historyResultMessage = chat.getMessage(5);
 
@@ -285,8 +283,7 @@ describe('History Messages', () => {
     historyCanceledMessage.scrollIntoView();
     historyCanceledMessage.confirmButton().should('not.exist');
     historyCanceledMessage.cancelButton().should('not.exist');
-    historyCanceledMessage.isCanceled().scrollIntoView();
-    historyCanceledMessage.containsText('Canceled');
+    historyCanceledMessage.isCanceled();
   });
 
   after(() => {

--- a/cypress/e2e/tests/features/message.spec.ts
+++ b/cypress/e2e/tests/features/message.spec.ts
@@ -234,6 +234,12 @@ describe('Messages', () => {
                 name:      'my-pod',
                 namespace: 'default'
               },
+              spec:       {
+                containers: [{
+                  name:  'my-container',
+                  image: 'nginx:latest'
+                }]
+              }
             },
             cluster:   'local',
             namespace: 'default'
@@ -255,12 +261,13 @@ describe('Messages', () => {
     confirmationRequestMessage.scrollIntoView();
     confirmationRequestMessage.containsText('Are you sure you want to proceed with this action?');
     confirmationRequestMessage.confirmButton().click();
+
     confirmationRequestMessage.isConfirmed();
-    confirmationRequestMessage.containsText('Confirmed');
 
     const resultMessage = chat.getMessage(4);
 
     resultMessage.containsText('Pod created successfully.');
+    resultMessage.resourceButton({ name: 'my-pod' }).should('exist');
   });
 
   it('Confirm multi-resource action', () => {
@@ -313,7 +320,6 @@ describe('Messages', () => {
     confirmationRequestMessage.containsText('Are you sure you want to proceed with this action?');
     confirmationRequestMessage.confirmButton().click();
     confirmationRequestMessage.isConfirmed();
-    confirmationRequestMessage.containsText('Confirmed');
 
     const resultMessage = chat.getMessage(4);
 
@@ -368,6 +374,8 @@ describe('Messages', () => {
   });
 
   after(() => {
+    cy.deleteRancherResource('v1', 'pods', 'default/my-pod', false);
+
     cy.clearLLMResponses();
     cy.uninstallUIToolsDefinition();
   });

--- a/cypress/e2e/tests/features/multi-agent/chat.spec.ts
+++ b/cypress/e2e/tests/features/multi-agent/chat.spec.ts
@@ -77,7 +77,7 @@ describe('Multi Agent Chat', () => {
 
       switchAgentMessage.confirmButton().click();
 
-      switchAgentMessage.isConfirmed();
+      switchAgentMessage.isConfirmed({ withLabel: 'Switched to Rancher Agent' });
 
       // Verify that the selection mode has been switched in the console
       const selectAgent = chat.console().selectAgent();
@@ -116,7 +116,7 @@ describe('Multi Agent Chat', () => {
 
       switchAgentMessage.cancelButton().click();
 
-      switchAgentMessage.isCanceled();
+      switchAgentMessage.isCanceled({ withLabel: 'Keeping adaptive selection' });
 
       // Verify that the selection mode is still adaptive in the console
       const selectAgent = chat.console().selectAgent();

--- a/cypress/e2e/tests/features/multi-agent/message.spec.ts
+++ b/cypress/e2e/tests/features/multi-agent/message.spec.ts
@@ -87,14 +87,20 @@ describe('Multi Agent Messages', () => {
           name: 'createKubernetesResource',
           args: {
             kind:      'Pod',
-            name:      'my-pod',
+            name:      'my-pod-2',
             resource:  {
               apiVersion: 'v1',
               kind:       'Pod',
               metadata:   {
-                name:      'my-pod',
+                name:      'my-pod-2',
                 namespace: 'default'
               },
+              spec: {
+                containers: [{
+                  name:  'my-container',
+                  image: 'nginx'
+                }]
+              }
             },
             cluster:   'local',
             namespace: 'default'
@@ -112,9 +118,10 @@ describe('Multi Agent Messages', () => {
     confirmationRequestMessage.isCompleted();
     confirmationRequestMessage.containsText('Are you sure you want to proceed with this action?');
     confirmationRequestMessage.confirmButton().click();
-    confirmationRequestMessage.isConfirmed();
-    confirmationRequestMessage.containsText('Confirmed');
+
     confirmationRequestMessage.agentSelectionLabel().contains('Adaptive Agent(s) Selection');
+    confirmationRequestMessage.resourceButton({ name: 'my-pod-2' }).should('exist');
+    confirmationRequestMessage.isConfirmed();
 
     let resultMessage = chat.getMessage(6);
 
@@ -144,6 +151,7 @@ describe('Multi Agent Messages', () => {
     resultMessage.scrollIntoView();
     resultMessage.containsText('Pod created successfully.');
     resultMessage.agentSelectionLabel().contains('Adaptive Agent(s) Selection');
+    resultMessage.resourceButton({ name: 'my-pod-2' }).should('exist');
   });
 
   it('It should correctly parse messages when agent selection is adaptive and multiple agents respond', () => {
@@ -323,6 +331,12 @@ describe('Multi Agent Messages', () => {
                 name:      'my-pod',
                 namespace: 'default'
               },
+              spec: {
+                containers: [{
+                  name:  'my-container',
+                  image: 'nginx'
+                }]
+              }
             },
             cluster:   'local',
             namespace: 'default'
@@ -340,13 +354,13 @@ describe('Multi Agent Messages', () => {
     confirmationRequestMessage.isCompleted();
     confirmationRequestMessage.containsText('Are you sure you want to proceed with this action?');
 
-    chat.processingState('Awaiting confirmation').should('be.visible');
+    chat.messagesPanel().processingState('Awaiting confirmation').should('be.visible');
 
     confirmationRequestMessage.confirmButton().click();
 
-    confirmationRequestMessage.isConfirmed();
-    confirmationRequestMessage.containsText('Confirmed');
     confirmationRequestMessage.agentSelectionLabel().contains(defaultAgent.displayName);
+    confirmationRequestMessage.isConfirmed();
+    confirmationRequestMessage.resourceButton({ name: 'my-pod' }).should('exist');
 
     let resultMessage = chat.getMessage(4);
 
@@ -401,13 +415,16 @@ describe('Multi Agent Messages', () => {
 
     confirmationRequestMessage.scrollIntoView();
     confirmationRequestMessage.agentSelectionLabel().contains(defaultAgent.displayName);
-    confirmationRequestMessage.containsText('Confirmed');
+
+    confirmationRequestMessage.confirmationStatus().scrollIntoView();
+    confirmationRequestMessage.isConfirmed();
 
     resultMessage = chat.getMessage(4);
 
     resultMessage.scrollIntoView();
     resultMessage.agentSelectionLabel().contains(defaultAgent.displayName);
     resultMessage.containsText('Pod created successfully.');
+    resultMessage.resourceButton({ name: 'my-pod' }).should('exist');
 
     responseMessage = chat.getMessage(6);
 
@@ -528,6 +545,11 @@ describe('Multi Agent Messages', () => {
   });
 
   after(() => {
+    cy.login();
+
+    cy.deleteRancherResource('v1', 'pods', 'default/my-pod', false);
+    cy.deleteRancherResource('v1', 'pods', 'default/my-pod-2', false);
+
     cy.deleteAgentConfig(harvesterAgentConfig);
     cy.cleanChatHistory();
     cy.clearLLMResponses();

--- a/cypress/e2e/tests/features/ui-tools.spec.ts
+++ b/cypress/e2e/tests/features/ui-tools.spec.ts
@@ -508,7 +508,6 @@ describe('UI Tools', () => {
         yamlEditor.checkNotExists();
 
         confirmationRequestMessage.isConfirmed();
-        confirmationRequestMessage.containsText('Confirmed');
 
         const confirmationResponseMessage = chat.getMessage(4);
 
@@ -632,7 +631,6 @@ describe('UI Tools', () => {
         yamlEditor.checkNotExists();
 
         confirmationRequestMessage.isConfirmed();
-        confirmationRequestMessage.containsText('Confirmed');
 
         const confirmationResponseMessage = chat.getMessage(4);
 
@@ -806,7 +804,6 @@ describe('UI Tools', () => {
         yamlEditor.checkNotExists();
 
         confirmationRequestMessage.isConfirmed();
-        confirmationRequestMessage.containsText('Confirmed');
 
         const confirmationResponseMessage = chat.getMessage(4);
 
@@ -926,7 +923,6 @@ describe('UI Tools', () => {
         yamlEditor.checkNotExists();
 
         confirmationRequestMessage.isConfirmed();
-        confirmationRequestMessage.containsText('Confirmed');
 
         const confirmationResponseMessage = chat.getMessage(4);
 

--- a/pkg/rancher-ai-ui/components/message/Confirmation.vue
+++ b/pkg/rancher-ai-ui/components/message/Confirmation.vue
@@ -20,6 +20,17 @@ const props = defineProps({
 
 const emit = defineEmits(['confirm']);
 
+const CONFIRMATION_STATUS: Partial<Record<ConfirmationStatus, { icon: string; label: string }>> = {
+  [ConfirmationStatus.Confirmed]: {
+    icon:  'icon icon-checkmark',
+    label: t('ai.confirmation.confirmed'),
+  },
+  [ConfirmationStatus.Canceled]: {
+    icon:  'icon icon-close',
+    label: t('ai.confirmation.canceled'),
+  },
+};
+
 const confirmationText = computed(() => {
   const msg = t('ai.confirmation.message.question');
 
@@ -131,9 +142,9 @@ const confirmationText = computed(() => {
       :class="`status-${ props.message.confirmation.status }`"
       :data-testid="`rancher-ai-ui-chat-message-confirmation-status-${ props.message.confirmation.status }`"
     >
-      <i :class="['icon', `icon-${ props.message.confirmation.status === ConfirmationStatus.Confirmed ? 'checkmark' : 'close'}` ]" />
+      <i :class="CONFIRMATION_STATUS[props.message.confirmation.status]?.icon" />
       <p>
-        {{ t(`ai.confirmation.${ props.message.confirmation.status }`) }}
+        {{ CONFIRMATION_STATUS[props.message.confirmation.status]?.label }}
       </p>
     </div>
     <Tools

--- a/pkg/rancher-ai-ui/components/message/Confirmation.vue
+++ b/pkg/rancher-ai-ui/components/message/Confirmation.vue
@@ -128,6 +128,7 @@ const confirmationText = computed(() => {
     <div
       v-else
       class="confirmation-status"
+      data-testid="rancher-ai-ui-chat-message-confirmation-status"
     >
       <template v-if="props.message.confirmation?.status === ConfirmationStatus.Confirmed">
         <div

--- a/pkg/rancher-ai-ui/components/message/Confirmation.vue
+++ b/pkg/rancher-ai-ui/components/message/Confirmation.vue
@@ -126,32 +126,15 @@ const confirmationText = computed(() => {
       </div>
     </div>
     <div
-      v-else
+      v-else-if="props.message.confirmation"
       class="confirmation-status"
-      data-testid="rancher-ai-ui-chat-message-confirmation-status"
+      :class="`status-${ props.message.confirmation.status }`"
+      :data-testid="`rancher-ai-ui-chat-message-confirmation-status-${ props.message.confirmation.status }`"
     >
-      <template v-if="props.message.confirmation?.status === ConfirmationStatus.Confirmed">
-        <div
-          class="status-confirmed"
-          data-testid="rancher-ai-ui-chat-message-confirmation-confirmed"
-        >
-          <i class="icon icon-checkmark" />
-          <p>
-            {{ t('ai.confirmation.confirmed') }}
-          </p>
-        </div>
-      </template>
-      <template v-else-if="props.message.confirmation?.status === ConfirmationStatus.Canceled">
-        <div
-          class="status-canceled"
-          data-testid="rancher-ai-ui-chat-message-confirmation-canceled"
-        >
-          <i class="icon icon-close canceled" />
-          <p>
-            {{ t('ai.confirmation.canceled') }}
-          </p>
-        </div>
-      </template>
+      <i :class="['icon', `icon-${ props.message.confirmation.status === ConfirmationStatus.Confirmed ? 'checkmark' : 'close'}` ]" />
+      <p>
+        {{ t(`ai.confirmation.${ props.message.confirmation.status }`) }}
+      </p>
     </div>
     <Tools
       :key="props.message.tools?.length"
@@ -214,20 +197,18 @@ const confirmationText = computed(() => {
 }
 
 .confirmation-status {
-  .status-confirmed , .status-canceled {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 4px;
-    justify-content: flex-end;
-  }
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  justify-content: flex-end;
 
-  .status-confirmed {
+  &.status-confirmed {
     .icon {
       color: var(--success);
     }
   }
-  .status-canceled {
+  &.status-canceled {
     .icon {
       color: var(--error);
     }

--- a/pkg/rancher-ai-ui/components/message/template/SystemRequest.vue
+++ b/pkg/rancher-ai-ui/components/message/template/SystemRequest.vue
@@ -58,7 +58,7 @@ function doAction(type: 'confirm' | 'cancel') {
       <div class="chat-system-request-actions">
         <div
           v-if="props.message.confirmation"
-          :data-testid="`rancher-ai-ui-chat-message-confirmation-${props.message.confirmation.status}`"
+          data-testid="rancher-ai-ui-chat-message-confirmation-status"
           :class="['chat-system-request-actions-result', `status-${props.message.confirmation.status}` ]"
         >
           <i :class="[ 'icon', props.message.confirmation.icon ]" />

--- a/pkg/rancher-ai-ui/components/message/template/SystemRequest.vue
+++ b/pkg/rancher-ai-ui/components/message/template/SystemRequest.vue
@@ -58,8 +58,9 @@ function doAction(type: 'confirm' | 'cancel') {
       <div class="chat-system-request-actions">
         <div
           v-if="props.message.confirmation"
-          data-testid="rancher-ai-ui-chat-message-confirmation-status"
-          :class="['chat-system-request-actions-result', `status-${props.message.confirmation.status}` ]"
+          class="chat-system-request-actions-result"
+          :class="`status-${props.message.confirmation.status}`"
+          :data-testid="`rancher-ai-ui-chat-message-confirmation-status-${ props.message.confirmation.status }`"
         >
           <i :class="[ 'icon', props.message.confirmation.icon ]" />
           <span

--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -160,6 +160,7 @@ export function useChatMessageComposable(
   function confirmMessage({ message, result }: { message: Message; result: boolean }, ws: WebSocket) {
     wsSend(ws, formatWSInputMessage({
       prompt: result ? ConfirmationResponse.Yes : ConfirmationResponse.No,
+      agent:  message.agentMetadata?.agent?.name || undefined, // This is required when Agent seleciton is manual
       tags:   [MessageTag.Confirmation]
     }));
 

--- a/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
+++ b/pkg/rancher-ai-ui/composables/useChatMessageComposable.ts
@@ -160,7 +160,7 @@ export function useChatMessageComposable(
   function confirmMessage({ message, result }: { message: Message; result: boolean }, ws: WebSocket) {
     wsSend(ws, formatWSInputMessage({
       prompt: result ? ConfirmationResponse.Yes : ConfirmationResponse.No,
-      agent:  message.agentMetadata?.agent?.name || undefined, // This is required when Agent seleciton is manual
+      agent:  message.agentMetadata?.agent?.name || undefined, // This is required when Agent selection is manual
       tags:   [MessageTag.Confirmation]
     }));
 


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-ui/issues/262

- We are sending now the agent name in the confirmation payload as required in the backend

### Notes

This is a regression from Subagents `feature`, the target release is 1.1.0 - we don't need a backport for this.