### PR TITLE
Update UI tools to support Continuous Delivery label

### DIFF
--- a/cypress/e2e/tests/features/context.spec.ts
+++ b/cypress/e2e/tests/features/context.spec.ts
@@ -144,27 +144,4 @@ describe('Feature: context', () => {
 
     cy.get('[data-testid="rancher-ai-ui-chat-container"]').screenshot('context-test-7-selected-context-in-message');
   });
-
-  describe('disabled state', () => {
-    afterEach(() => {
-      cy.uninstallRancherAIService();
-      cy.installRancherAIService();
-    });
-
-    it('Test 8: Context panel is disabled when AI service is not active', () => {
-      cy.installRancherAIService({ waitForAIServiceReady: false });
-
-      const deploymentsListPage = new WorkloadsDeploymentsListPagePo('local', 'apps.deployment' as any);
-
-      deploymentsListPage.goTo();
-      deploymentsListPage.waitForPage();
-
-      cy.get('[data-testid="extension-header-action-ai.action.openChat"]').should('be.visible');
-      chat.open();
-
-      context.isDisabled();
-
-      cy.get('[data-testid="rancher-ai-ui-chat-container"]').screenshot('context-test-8-disabled-when-not-active');
-    });
-  });
 });

--- a/pkg/rancher-ai-ui/components/tools/components/Explore.vue
+++ b/pkg/rancher-ai-ui/components/tools/components/Explore.vue
@@ -21,7 +21,7 @@ const enum ROUTE_ID {
   Events = 'events', // eslint-disable-line no-unused-vars
   Charts = 'charts', // eslint-disable-line no-unused-vars
   Clusters = 'clusters', // eslint-disable-line no-unused-vars
-  Fleet = 'fleet', // eslint-disable-line no-unused-vars
+  ContinuousDelivery = 'continuous-delivery', // eslint-disable-line no-unused-vars
   Users = 'users', // eslint-disable-line no-unused-vars
   Settings = 'settings', // eslint-disable-line no-unused-vars
   Deployments = 'deployments', // eslint-disable-line no-unused-vars
@@ -49,7 +49,7 @@ const ROUTES: Record<string, RouteConfig> = {
     schema:  'provisioning.cattle.io.cluster',
     resolve: () => '/c/_/manager/provisioning.cattle.io.cluster',
   },
-  [ROUTE_ID.Fleet]: {
+  [ROUTE_ID.ContinuousDelivery]: {
     schema:  FLEET.GIT_REPO,
     resolve: () => '/c/_/fleet',
   },

--- a/pkg/rancher-ai-ui/ui-tools.json
+++ b/pkg/rancher-ai-ui/ui-tools.json
@@ -182,8 +182,8 @@
             "clusters": {
               "description": "SCOPE: list or collection, this route shows the list of clusters in Rancher. Use this route when the context is about listing clusters or cluster management."
             },
-            "fleet": {
-              "description": "This route shows the Fleet dashboard. Use this route when the context is about managing or listing Fleet resources."
+            "continuous-delivery": {
+              "description": "This route shows the Continuous Delivery dashboard. Use this route when the context is about managing or listing Fleet resources."
             },
             "users": {
               "description": "This route shows the Users management page. Use this route when the context is about managing users, roles, or permissions."

--- a/pkg/rancher-ai-ui/ui-tools.json
+++ b/pkg/rancher-ai-ui/ui-tools.json
@@ -131,7 +131,7 @@
               "events",
               "clusters",
               "charts",
-              "fleet",
+              "continuous-delivery",
               "users",
               "settings",
               "deployments",


### PR DESCRIPTION
Contributes to https://github.com/rancher/rancher-ai-ui/issues/245

This change updates the `explore` UI tool in order to generate "Continuous Delivery" routes instead of "Fleet"