### PR TITLE
Explore provisioning clusters

### DIFF
--- a/cypress/e2e/blueprints/cluster.ts
+++ b/cypress/e2e/blueprints/cluster.ts
@@ -1,0 +1,12 @@
+export const provisioningCluster = {
+  type:     'provisioning.cattle.io.cluster',
+  metadata: {
+    name:      'e2e-provisioning-cluster',
+    namespace: 'fleet-default',
+    labels:    { 'e2e-test': 'true' }
+  },
+  spec: {
+    kubernetesVersion: 'v1.28.0',
+    rkeConfig:         {}
+  }
+};

--- a/cypress/e2e/tests/features/message/message-resource-button.spec.ts
+++ b/cypress/e2e/tests/features/message/message-resource-button.spec.ts
@@ -4,6 +4,7 @@ import HomePagePo from '@rancher/cypress/e2e/po/pages/home.po';
 import ChatPo from '@/cypress/e2e/po/chat.po';
 import { machineInventorySchema } from '@/cypress/e2e/blueprints/schema';
 import { gitRepo } from '@/cypress/e2e/blueprints/fleet';
+import { provisioningCluster } from '@/cypress/e2e/blueprints/cluster';
 
 // Resource buttons fetch their schema lazily, when the button scrolls into view (intersection
 // observer). That request can take well over the 5s cy.wait default to fire on the loaded CI
@@ -262,6 +263,7 @@ describe('Resource button', () => {
       cy.login();
 
       cy.createRancherResource('v1', 'fleet.cattle.io.gitrepo', JSON.stringify(gitRepo), false);
+      cy.createRancherResource('v1', 'provisioning.cattle.io.clusters', JSON.stringify(provisioningCluster), false);
     });
 
     beforeEach(() => {
@@ -320,6 +322,52 @@ describe('Resource button', () => {
 
       cy.url().should('include', '/c/local/explorer/apps.deployment/cattle-ai-agent-system/llm-mock');
       cy.get('[data-testid="resource-detail-status-card"]').should('contain.text', 'Pods');
+    });
+
+    it('It should correctly navigate to built-in product (Cluster Management) when resource is provisioning cluster', () => {
+      cy.getRancherResource('v1', 'provisioning.cattle.io.clusters', `fleet-default/${ provisioningCluster.metadata.name }`).then((resp) => {
+        cy.enqueueLLMResponse({
+          text: [
+            'test',
+            /**
+             * Resource
+             *
+             *   cluster: local
+             *   type: management.cattle.io.cluster
+             *   namespace: ""
+             *   name: "${ resp.body.status.clusterName }"
+             */
+            `<mcp-response>[{"namespace": "", "kind": "Cluster", "cluster": "local", "name": "${ resp.body.status.clusterName }", "type": "management.cattle.io.cluster"}]</mcp-response>`,
+          ],
+        });
+
+        chat.sendMessage('User request');
+
+        const resourceMessage = chat.getMessage(3);
+
+        resourceMessage.isCompleted();
+
+        const btn = resourceMessage.resourceButton({ name: resp.body.status.clusterName });
+
+        // Verify navigation from Home to Cluster Management
+        btn.should('be.visible');
+        btn.click();
+
+        cy.url().should('include', '/c/_/manager/provisioning.cattle.io.cluster/fleet-default/e2e-provisioning-cluster#registration');
+        cy.get('.resource-link').should('contain.text', 'Cluster:');
+
+        // Verify navigation Explorer to Cluster Management
+        burgerMenu.goToCluster('local');
+        sideNav.navToSideMenuGroupByLabel('Workloads');
+        sideNav.navToSideMenuEntryByLabel('Deployments');
+        cy.get('.with-subheader').should('contain.text', 'Deployments');
+
+        btn.scrollIntoView();
+        btn.click();
+
+        cy.url().should('include', '/c/_/manager/provisioning.cattle.io.cluster/fleet-default/e2e-provisioning-cluster#registration');
+        cy.get('.resource-link').should('contain.text', 'Cluster:');
+      });
     });
 
     it('It should correctly navigate to built-in product (Fleet) when resource is fleet resource', () => {
@@ -387,6 +435,7 @@ describe('Resource button', () => {
       cy.login();
 
       cy.deleteRancherResource('v1', 'fleet.cattle.io.gitrepo', `${ gitRepo.metadata.namespace }/${ gitRepo.metadata.name }`, false);
+      cy.deleteRancherResource('v1', 'provisioning.cattle.io.clusters', `${ provisioningCluster.metadata.namespace }/${ provisioningCluster.metadata.name }`, false);
     });
   });
 });

--- a/pkg/rancher-ai-ui/components/message/resource-buttons/ResourceButton.vue
+++ b/pkg/rancher-ai-ui/components/message/resource-buttons/ResourceButton.vue
@@ -152,7 +152,8 @@ function goTo() {
     product.value.name,
     schema.value,
     inStore.value,
-    props.value.resource
+    props.value.resource,
+    resource.value
   );
 
   if (!detailLocation) {

--- a/pkg/rancher-ai-ui/components/message/resource-buttons/__tests__/resource-context.test.ts
+++ b/pkg/rancher-ai-ui/components/message/resource-buttons/__tests__/resource-context.test.ts
@@ -12,7 +12,8 @@ import {
   normalizeId,
   normalizeNamespace,
   getProduct,
-  getDetailLocation
+  getDetailLocation,
+  getKnownRoute
 } from '../resource-context';
 import type { Store as VuexStore } from 'vuex';
 
@@ -949,6 +950,83 @@ describe('resource-context', () => {
     });
   });
 
+  describe('getKnownRoute', () => {
+    it('should return known route for MANAGEMENT_CLUSTER with local cluster', () => {
+      const actionResource = { name: 'local' };
+      const rancherResource = {
+        type:        'management.cattle.io.cluster',
+        nameDisplay: 'local'
+      };
+
+      const result = getKnownRoute(actionResource, rancherResource);
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('c-cluster-product-resource-namespace-id');
+      expect(result?.params?.product).toBe('manager');
+      expect(result?.params?.cluster).toBe('_');
+      expect(result?.params?.resource).toBe('provisioning.cattle.io.cluster');
+      expect(result?.params?.namespace).toBe('fleet-local');
+      expect(result?.params?.id).toBe('local');
+    });
+
+    it('should return known route for MANAGEMENT_CLUSTER with non-local cluster', () => {
+      const actionResource = { name: 'custom-cluster' };
+      const rancherResource = {
+        type:        'management.cattle.io.cluster',
+        nameDisplay: 'my-cluster'
+      };
+
+      const result = getKnownRoute(actionResource, rancherResource);
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('c-cluster-product-resource-namespace-id');
+      expect(result?.params?.namespace).toBe('fleet-default');
+      expect(result?.params?.id).toBe('my-cluster');
+    });
+
+    it('should return null for MANAGEMENT_CLUSTER without actionResource.name', () => {
+      const actionResource = {};
+      const rancherResource = {
+        type:        'management.cattle.io.cluster',
+        nameDisplay: 'local'
+      };
+
+      const result = getKnownRoute(actionResource, rancherResource);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for MANAGEMENT_CLUSTER without rancherResource.nameDisplay', () => {
+      const actionResource = { name: 'local' };
+      const rancherResource = { type: 'management.cattle.io.cluster' };
+
+      const result = getKnownRoute(actionResource, rancherResource);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for unknown resource type', () => {
+      const actionResource = { name: 'local' };
+      const rancherResource = {
+        type:        'management.cattle.io.project',
+        nameDisplay: 'Project Name'
+      };
+
+      const result = getKnownRoute(actionResource, rancherResource);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when rancherResource.type is undefined', () => {
+      const actionResource = { name: 'local' };
+      const rancherResource = { nameDisplay: 'Display Name' };
+
+      const result = getKnownRoute(actionResource, rancherResource);
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('getDetailLocation', () => {
     beforeEach(() => {
       mockStore.getters[`${ STORE.MANAGEMENT }/classify`] = jest.fn(() => {
@@ -1221,6 +1299,91 @@ describe('resource-context', () => {
           getDetailLocation(mockStore, productName, schema, inStore, resource);
         }).not.toThrow();
       });
+    });
+
+    it('should return known route for MANAGEMENT_CLUSTER resource with local cluster', () => {
+      const rancherResource = {
+        type:        'management.cattle.io.cluster',
+        nameDisplay: 'local'
+      };
+
+      const result = getDetailLocation(
+        mockStore,
+        'manager',
+        null,
+        STORE.MANAGEMENT,
+        { name: 'local' },
+        rancherResource
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('c-cluster-product-resource-namespace-id');
+      expect(result?.params?.namespace).toBe('fleet-local');
+      expect(result?.params?.id).toBe('local');
+    });
+
+    it('should return known route for MANAGEMENT_CLUSTER resource with non-local cluster', () => {
+      const rancherResource = {
+        type:        'management.cattle.io.cluster',
+        nameDisplay: 'my-cluster'
+      };
+
+      const result = getDetailLocation(
+        mockStore,
+        'manager',
+        null,
+        STORE.MANAGEMENT,
+        { name: 'custom-cluster' },
+        rancherResource
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('c-cluster-product-resource-namespace-id');
+      expect(result?.params?.namespace).toBe('fleet-default');
+      expect(result?.params?.id).toBe('my-cluster');
+    });
+
+    it('should skip getKnownRoute and build detail location when rancherResource is empty', () => {
+      const result = getDetailLocation(
+        mockStore,
+        'explorer',
+        null,
+        STORE.MANAGEMENT,
+        {
+          cluster:   'local',
+          type:      'deployment',
+          namespace: 'default',
+          name:      'my-deployment'
+        },
+        {}
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('c-cluster-resource-details');
+    });
+
+    it('should fall back to buildDetailLocation when getKnownRoute returns null', () => {
+      const rancherResource = {
+        type: 'management.cattle.io.cluster'
+        // Missing nameDisplay, so getKnownRoute will return null
+      };
+
+      const result = getDetailLocation(
+        mockStore,
+        'explorer',
+        null,
+        STORE.MANAGEMENT,
+        {
+          cluster:   'local',
+          type:      'deployment',
+          namespace: 'default',
+          name:      'my-deployment'
+        },
+        rancherResource
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('c-cluster-resource-details');
     });
   });
 });

--- a/pkg/rancher-ai-ui/components/message/resource-buttons/resource-context.ts
+++ b/pkg/rancher-ai-ui/components/message/resource-buttons/resource-context.ts
@@ -283,9 +283,9 @@ export function getKnownRoute(actionResource: ActionResource, rancherResource: R
         }
       };
     }
+  default:
+    return null;
   }
-
-  return null;
 }
 
 /**

--- a/pkg/rancher-ai-ui/components/message/resource-buttons/resource-context.ts
+++ b/pkg/rancher-ai-ui/components/message/resource-buttons/resource-context.ts
@@ -252,12 +252,10 @@ export function getDetailLocation(
   actionResource: ActionResource = {},
   rancherResource: RancherResource = {},
 ) {
-  if (rancherResource) {
-    const route = getKnownRoute(actionResource, rancherResource);
+  const route = getKnownRoute(actionResource, rancherResource);
 
-    if (route) {
-      return route;
-    }
+  if (route) {
+    return route;
   }
 
   return buildDetailLocation(store, productName, schema, inStore, actionResource);
@@ -271,6 +269,7 @@ export function getDetailLocation(
  */
 export function getKnownRoute(actionResource: ActionResource, rancherResource: RancherResource) {
   switch (rancherResource.type) {
+  // Add any known routes for built-in products here
   case MANAGEMENT_CLUSTER:
     if (actionResource.name && rancherResource.nameDisplay) {
       return {

--- a/pkg/rancher-ai-ui/components/message/resource-buttons/resource-context.ts
+++ b/pkg/rancher-ai-ui/components/message/resource-buttons/resource-context.ts
@@ -18,6 +18,11 @@ interface Product {
   inStore?: string;
 }
 
+interface RancherResource {
+  type?: string;
+  nameDisplay?: string;
+}
+
 interface DetailLocation {
   name: string;
   params?: Record<string, string>;
@@ -25,14 +30,23 @@ interface DetailLocation {
 }
 
 const PRODUCT = {
+  MANAGER:  'manager',
   EXPLORER: 'explorer',
   FLEET:    'fleet',
 };
 
 const RANCHER_STORES = [STORE.MANAGEMENT, STORE.CLUSTER, STORE.RANCHER];
 
+const NAMESPACE = {
+  FLEET_LOCAL:   'fleet-local',
+  FLEET_DEFAULT: 'fleet-default',
+};
+
 const MANAGEMENT_GROUP = 'management.cattle.io';
 const FLEET_GROUP = 'fleet.cattle.io';
+
+const MANAGEMENT_CLUSTER = 'management.cattle.io.cluster';
+const PROVISIONING_CLUSTER = 'provisioning.cattle.io.cluster';
 
 const NODE_METRICS = 'nodemetrics';
 const POD_METRICS = 'podmetrics';
@@ -220,6 +234,62 @@ export function getProduct(store: Store, schema: Schema | null, resourceType = '
 }
 
 /**
+ * Get the detail location for a given resource, handling built-in product's routes.
+ *
+ * @param store - The Vuex store instance
+ * @param productName - The name of the product that owns the resource
+ * @param schema - The schema object for the resource type (can be null)
+ * @param inStore - The store context (e.g., 'management', 'cluster')
+ * @param actionResource - The resource object returned from the message action
+ * @param rancherResource - The Rancher-specific resource object
+ * @returns The detail location object if available, otherwise null
+ */
+export function getDetailLocation(
+  store: Store,
+  productName: string,
+  schema: Schema | null,
+  inStore: string,
+  actionResource: ActionResource = {},
+  rancherResource: RancherResource = {},
+) {
+  if (rancherResource) {
+    const route = getKnownRoute(actionResource, rancherResource);
+
+    if (route) {
+      return route;
+    }
+  }
+
+  return buildDetailLocation(store, productName, schema, inStore, actionResource);
+}
+
+/**
+ * Get the route for built-in products, for a given action resource and rancher resource.
+ * @param actionResource the resource returned from the message action
+ * @param rancherResource the resource returned from the rancher API
+ * @returns an object containing the route name and parameters for the resource
+ */
+export function getKnownRoute(actionResource: ActionResource, rancherResource: RancherResource) {
+  switch (rancherResource.type) {
+  case MANAGEMENT_CLUSTER:
+    if (actionResource.name && rancherResource.nameDisplay) {
+      return {
+        name:   'c-cluster-product-resource-namespace-id',
+        params: {
+          product:   PRODUCT.MANAGER,
+          cluster:   '_',
+          resource:  PROVISIONING_CLUSTER,
+          namespace: actionResource.name === 'local' ? NAMESPACE.FLEET_LOCAL : NAMESPACE.FLEET_DEFAULT,
+          id:        rancherResource.nameDisplay
+        }
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
  * Get the detail location for a given resource by instantiating its model and accessing the detailLocation getter.
  * This function handles the necessary context for the model to work correctly, including getters and rootGetters.
  *
@@ -229,7 +299,7 @@ export function getProduct(store: Store, schema: Schema | null, resourceType = '
  * @param resource - The resource object containing cluster, type, namespace, and name
  * @returns The detail location object if available, otherwise null
  */
-export function getDetailLocation(
+function buildDetailLocation(
   store: Store,
   productName: string,
   schema: Schema | null,


### PR DESCRIPTION
When the action resource is a CLuster, we can directly redirect to the Cluster Management product, which is built-in and the route is known.