### PR TITLE
Add Privacy Notice banner to Local provider

### DIFF
--- a/pkg/rancher-ai-ui/l10n/en-us.yaml
+++ b/pkg/rancher-ai-ui/l10n/en-us.yaml
@@ -358,8 +358,10 @@ aiConfig:
         banner:
           privacy:
             header: "Privacy Notice:"
-            description: 'When using external, third-party providers, please be aware that SUSE does not own or control this LLM and is not responsible for its output. Your prompts and data will be sent to the provider’s servers (e.g., Google’s servers for Gemini). These providers may use your data according to their own privacy policies. The additional risk with public LLMs is the much wider dataset they use for training. Your input data could potentially be incorporated into that dataset, making it accessible to other users or used for future model training.<br><br>For highly sensitive or confidential information, we strongly recommend using a local provider instead.'
-          thirdParty:
+            description:
+              local: 'Please be aware that SUSE does not own or control this LLM and is not responsible for its output.<br><br>Your prompts and data will be sent to the provider’s servers. These providers may use your data according to their own privacy policies.'
+              thirdParty: 'Please be aware that SUSE does not own or control this LLM and is not responsible for its output.<br><br>Your prompts and data will be sent to the provider’s servers (e.g., Google’s servers for Gemini). These providers may use your data according to their own privacy policies. The additional risk with public LLMs is the much wider dataset they use for training. Your input data could potentially be incorporated into that dataset, making it accessible to other users or used for future model training.<br><br>For highly sensitive or confidential information, we strongly recommend using a local provider instead.'
+          genericOpenAI:
             description: 'Use this option if you want to configure another AI provider using OpenAI API standards (e.g. same protocol, same structure, ...)'
         noPermission:
           list: You do not have permission to view or edit the AI Provider settings. Please contact your administrator or refer to our <docsUrl>documentation</docsUrl>.

--- a/pkg/rancher-ai-ui/pages/settings/sections/AIAgentSettings.vue
+++ b/pkg/rancher-ai-ui/pages/settings/sections/AIAgentSettings.vue
@@ -519,14 +519,14 @@ onMounted(() => {
       @update:model-value="(val: string | undefined) => updateChatbotValue(val as ChatBotEnum)"
     />
     <banner
-      v-if="formData[Settings.ACTIVE_CHATBOT] !== ChatBotEnum.Local && !readOnly"
+      v-if="!readOnly"
       color="warning"
       class="mt-0 mb-0"
     >
       <span>
         <b>{{ t('aiConfig.form.section.provider.banner.privacy.header', {}, true) }}</b>
         <br>
-        <span v-clean-html="t('aiConfig.form.section.provider.banner.privacy.description', {}, true)" />
+        <span v-clean-html="t(`aiConfig.form.section.provider.banner.privacy.description.${ formData[Settings.ACTIVE_CHATBOT] === ChatBotEnum.Local ? 'local' : 'thirdParty' }`, {}, true)" />
       </span>
     </banner>
 
@@ -535,7 +535,7 @@ onMounted(() => {
       color="info"
       class="mt-0 mb-0"
     >
-      <span v-clean-html="t('aiConfig.form.section.provider.banner.thirdParty.description', {}, true)" />
+      <span v-clean-html="t('aiConfig.form.section.provider.banner.genericOpenAI.description', {}, true)" />
     </banner>
 
     <div

--- a/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentSettings.test.ts
+++ b/pkg/rancher-ai-ui/pages/settings/sections/__tests__/AIAgentSettings.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount, flushPromises } from '@vue/test-utils';
+import { shallowMount, mount, flushPromises } from '@vue/test-utils';
 import AIAgentSettings from '../AIAgentSettings.vue';
 import { Settings, SettingsFormData, ValidationStatus } from '../../types';
 import { LLMProvider as ChatBotEnum } from '../../../../types';
@@ -34,8 +34,17 @@ jest.mock('vuex', () => {
   };
 });
 
+// Mock useI18n composable
+jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+
 const requiredSetup = () => {
-  return { directives: { 'clean-html': jest.fn() } };
+  return {
+    directives: {
+      'clean-html': (el: any, binding: any) => {
+        el.innerHTML = binding.value;
+      }
+    }
+  };
 };
 
 describe('AIAgentSettings.vue', () => {
@@ -84,39 +93,56 @@ describe('AIAgentSettings.vue', () => {
     });
   });
 
-  describe('Warning Banner', () => {
-    it('should show warning banner for OpenAI', () => {
-      const wrapper = shallowMount(AIAgentSettings, {
+  describe('Banners', () => {
+    it('should show privacy banner for third-party providers', () => {
+      const wrapper = mount(AIAgentSettings, {
         ...requiredSetup(),
         props: { value: { [Settings.ACTIVE_CHATBOT]: ChatBotEnum.OpenAI } as SettingsFormData },
       });
 
-      const banners = wrapper.findAllComponents({ name: 'Banner' });
+      const banner = wrapper.findComponent({ name: 'Banner' });
 
-      expect(banners.length).toBeGreaterThan(0);
+      expect(banner.props('color')).toBe('warning');
+
+      const bannerHtml = banner.html();
+
+      expect(bannerHtml).toContain('aiConfig.form.section.provider.banner.privacy.description.thirdParty');
     });
 
-    it('should show warning banner for Gemini', () => {
-      const wrapper = shallowMount(AIAgentSettings, {
-        ...requiredSetup(),
-        props: { value: { [Settings.ACTIVE_CHATBOT]: ChatBotEnum.Gemini } as SettingsFormData },
-      });
-
-      const banners = wrapper.findAllComponents({ name: 'Banner' });
-
-      expect(banners.length).toBeGreaterThan(0);
-    });
-
-    it('should not show warning banner for Local chatbot', () => {
-      const wrapper = shallowMount(AIAgentSettings, {
+    it('should show privacy banner for Local provider', () => {
+      const wrapper = mount(AIAgentSettings, {
         ...requiredSetup(),
         props: { value: { [Settings.ACTIVE_CHATBOT]: ChatBotEnum.Local } as SettingsFormData },
       });
 
-      const banners = wrapper.findAllComponents({ name: 'Banner' });
-      const warningBanners = banners.filter((b) => b.props('color') === 'warning');
+      const banner = wrapper.findComponent({ name: 'Banner' });
 
-      expect(warningBanners.length).toBe(0);
+      expect(banner.props('color')).toBe('warning');
+
+      const bannerHtml = banner.html();
+
+      expect(bannerHtml).toContain('aiConfig.form.section.provider.banner.privacy.description.local');
+    });
+
+    it('should show privacy and info banner for GenericOpenAI provider', () => {
+      const wrapper = mount(AIAgentSettings, {
+        ...requiredSetup(),
+        props: { value: { [Settings.ACTIVE_CHATBOT]: ChatBotEnum.GenericOpenAI } as SettingsFormData },
+      });
+
+      const banner = wrapper.findAllComponents({ name: 'Banner' });
+
+      expect(banner[0].props('color')).toBe('warning');
+
+      const bannerHtml = banner[0].html();
+
+      expect(bannerHtml).toContain('aiConfig.form.section.provider.banner.privacy.description.thirdParty');
+
+      expect(banner[1].props('color')).toBe('info');
+
+      const bannerHtml1 = banner[1].html();
+
+      expect(bannerHtml1).toContain('aiConfig.form.section.provider.banner.genericOpenAI.description');
     });
   });
 


### PR DESCRIPTION
Fixes: https://github.com/rancher/rancher-ai-ui/issues/194

We are adding the privacy notice to the `Local` provider and fixing the text of `third-party`'s for consistency (the first line is now the same for all providers)


### Screenshots

Local:

<img width="989" height="376" alt="image" src="https://github.com/user-attachments/assets/7bab24da-062c-46b2-ae05-28b8b1022b62" />


Others:


<img width="985" height="452" alt="image" src="https://github.com/user-attachments/assets/2e37f896-440b-42e4-9abf-5e4549c097e7" />
