### PR TITLE
Helm Chart and k3s version dynamic fetch

### DIFF
--- a/.github/scripts/install-rancher-helm.sh
+++ b/.github/scripts/install-rancher-helm.sh
@@ -8,10 +8,10 @@
 # external extension server), mirroring rancher/dashboard's Extension Compatibility test.
 #
 # Usage: install-rancher-helm.sh [VERSION] [CATTLE_SERVER_URL] [CATTLE_BOOTSTRAP_PASSWORD] \
-#                                [RANCHER_CHART_CHANNEL] [K3S_VERSION]
+#                                [RANCHER_HELM_REPO_URL] [K3S_VERSION]
 #
 #   VERSION               Rancher image tag, default `head`.
-#   RANCHER_CHART_CHANNEL Chart channel served by the Rancher chart repo, default `latest`.
+#   RANCHER_HELM_REPO_URL Rancher Helm repo URL, default `https://charts.optimus.rancher.io/server-charts/<RANCHER_CHART_CHANNEL>`.
 #                         Also accepts a release branch, e.g. `release-2.15`.
 #   K3S_VERSION           k3s version to install, default `latest` (the k3s stable channel).
 #                         Also accepts a pinned version, e.g. `v1.36.1+k3s1`.
@@ -23,20 +23,19 @@ set -e
 VERSION="head"
 CATTLE_SERVER_URL="https://127.0.0.1.sslip.io"
 CATTLE_BOOTSTRAP_PASSWORD="password"
-RANCHER_CHART_CHANNEL="${RANCHER_CHART_CHANNEL:-latest}"
+RANCHER_HELM_REPO_URL="${RANCHER_HELM_REPO_URL:-https://charts.optimus.rancher.io/server-charts/latest}"
 K3S_VERSION="${K3S_VERSION:-latest}"
 
 if [ -n "$1" ]; then VERSION=$1; fi
 if [ -n "$2" ]; then CATTLE_SERVER_URL="$2"; fi
 if [ -n "$3" ]; then CATTLE_BOOTSTRAP_PASSWORD="$3"; fi
-if [ -n "$4" ]; then RANCHER_CHART_CHANNEL="$4"; fi
+if [ -n "$4" ]; then RANCHER_HELM_REPO_URL="$4"; fi
 if [ -n "$5" ]; then K3S_VERSION="$5"; fi
 
 # ---------------------------------
 # ----------------------- Config
 # ---------------------------------
 
-RANCHER_HELM_REPO_URL=${RANCHER_HELM_REPO_URL:-https://charts.optimus.rancher.io/server-charts/${RANCHER_CHART_CHANNEL}}
 RANCHER_HELM_REPO_NAME=rancher-helm
 RANCHER_NAMESPACE=cattle-system
 

--- a/.github/scripts/load-rancher-branches-metadata.sh
+++ b/.github/scripts/load-rancher-branches-metadata.sh
@@ -25,7 +25,7 @@ if ! METADATA=$(curl -s -f "$BRANCHES_METADATA_URL"); then
 fi
 
 # Verify the helm section exists
-if ! echo "$METADATA" | jq -e ".branches.$BRANCH_NAME.e2e.helm" > /dev/null 2>&1; then
+if ! echo "$METADATA" | jq -e --arg branch "$BRANCH_NAME" '.branches[$branch].e2e.helm' > /dev/null 2>&1; then
   echo "Error: Missing 'helm' section for branch '$BRANCH_NAME'"
   echo "Expected path: .branches.$BRANCH_NAME.e2e.helm"
   echo "Available branches: $(echo "$METADATA" | jq -r '.branches | keys | join(", ")')"
@@ -33,14 +33,14 @@ if ! echo "$METADATA" | jq -e ".branches.$BRANCH_NAME.e2e.helm" > /dev/null 2>&1
 fi
 
 # Verify the kube section exists
-if ! echo "$METADATA" | jq -e ".branches.$BRANCH_NAME.e2e.kube" > /dev/null 2>&1; then
+if ! echo "$METADATA" | jq -e --arg branch "$BRANCH_NAME" '.branches[$branch].e2e.kube' > /dev/null 2>&1; then
   echo "Error: Missing 'kube' section for branch '$BRANCH_NAME'"
   echo "Expected path: .branches.$BRANCH_NAME.e2e.kube"
   exit 1
 fi
 
 # Extract kube version
-K3S_VERSION=$(echo "$METADATA" | jq -r ".branches.$BRANCH_NAME.e2e.kube.version")
+K3S_VERSION=$(echo "$METADATA" | jq -r --arg branch "$BRANCH_NAME" '.branches[$branch].e2e.kube.version')
 
 # Validate K3S_VERSION
 if [[ -z "$K3S_VERSION" ]] || [[ "$K3S_VERSION" == "null" ]]; then
@@ -50,7 +50,7 @@ if [[ -z "$K3S_VERSION" ]] || [[ "$K3S_VERSION" == "null" ]]; then
 fi
 
 # Extract helm repo URL
-RANCHER_HELM_REPO_URL=$(echo "$METADATA" | jq -r ".branches.$BRANCH_NAME.e2e.helm[\"repo-url\"]")
+RANCHER_HELM_REPO_URL=$(echo "$METADATA" | jq -r --arg branch "$BRANCH_NAME" '.branches[$branch].e2e.helm["repo-url"]')
 
 # Validate RANCHER_HELM_REPO_URL
 if [[ -z "$RANCHER_HELM_REPO_URL" ]] || [[ "$RANCHER_HELM_REPO_URL" == "null" ]]; then

--- a/.github/scripts/load-rancher-branches-metadata.sh
+++ b/.github/scripts/load-rancher-branches-metadata.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Helper script to load Rancher branches metadata from a JSON file and set outputs for GitHub Actions.
+
+set -e
+
+BRANCHES_METADATA_URL="${1}"
+BRANCH_NAME="${2}"
+
+if [[ -z "$BRANCHES_METADATA_URL" ]]; then
+  echo "Error: BRANCHES_METADATA_URL is required as the first argument"
+  exit 1
+fi
+
+if [[ -z "$BRANCH_NAME" ]]; then
+  echo "Error: BRANCH_NAME is required as the second argument"
+  exit 1
+fi
+
+# Fetch the metadata file
+if ! METADATA=$(curl -s -f "$BRANCHES_METADATA_URL"); then
+  echo "Error: Failed to fetch metadata from $BRANCHES_METADATA_URL"
+  echo "Check that the URL is correct and the file exists"
+  exit 1
+fi
+
+# Verify the helm section exists
+if ! echo "$METADATA" | jq -e ".branches.$BRANCH_NAME.e2e.helm" > /dev/null 2>&1; then
+  echo "Error: Missing 'helm' section for branch '$BRANCH_NAME'"
+  echo "Expected path: .branches.$BRANCH_NAME.e2e.helm"
+  echo "Available branches: $(echo "$METADATA" | jq -r '.branches | keys | join(", ")')"
+  exit 1
+fi
+
+# Verify the kube section exists
+if ! echo "$METADATA" | jq -e ".branches.$BRANCH_NAME.e2e.kube" > /dev/null 2>&1; then
+  echo "Error: Missing 'kube' section for branch '$BRANCH_NAME'"
+  echo "Expected path: .branches.$BRANCH_NAME.e2e.kube"
+  exit 1
+fi
+
+# Extract kube version
+K3S_VERSION=$(echo "$METADATA" | jq -r ".branches.$BRANCH_NAME.e2e.kube.version")
+
+# Validate K3S_VERSION
+if [[ -z "$K3S_VERSION" ]] || [[ "$K3S_VERSION" == "null" ]]; then
+  echo "Error: k3s version is empty or null for branch '$BRANCH_NAME'"
+  echo "Metadata path: .branches.$BRANCH_NAME.e2e.kube.version"
+  exit 1
+fi
+
+# Extract helm repo URL
+RANCHER_HELM_REPO_URL=$(echo "$METADATA" | jq -r ".branches.$BRANCH_NAME.e2e.helm[\"repo-url\"]")
+
+# Validate RANCHER_HELM_REPO_URL
+if [[ -z "$RANCHER_HELM_REPO_URL" ]] || [[ "$RANCHER_HELM_REPO_URL" == "null" ]]; then
+  echo "Error: Helm repo URL is empty or null for branch '$BRANCH_NAME'"
+  echo "Metadata path: .branches.$BRANCH_NAME.e2e.helm[\"repo-url\"]"
+  exit 1
+fi
+
+# Log extracted values
+echo "Successfully extracted metadata for branch: $BRANCH_NAME"
+echo "  K3S_VERSION: $K3S_VERSION"
+echo "  RANCHER_HELM_REPO_URL: $RANCHER_HELM_REPO_URL"
+
+# Set outputs for other jobs
+echo "K3S_VERSION=$K3S_VERSION" >> "$GITHUB_OUTPUT"
+echo "RANCHER_HELM_REPO_URL=$RANCHER_HELM_REPO_URL" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/load-rancher-branches-metadata.sh
+++ b/.github/scripts/load-rancher-branches-metadata.sh
@@ -64,6 +64,6 @@ echo "Successfully extracted metadata for branch: $BRANCH_NAME"
 echo "  K3S_VERSION: $K3S_VERSION"
 echo "  RANCHER_HELM_REPO_URL: $RANCHER_HELM_REPO_URL"
 
-# Set outputs for other jobs
-echo "K3S_VERSION=$K3S_VERSION" >> "$GITHUB_OUTPUT"
-echo "RANCHER_HELM_REPO_URL=$RANCHER_HELM_REPO_URL" >> "$GITHUB_OUTPUT"
+# Set environment variables for subsequent job steps
+echo "K3S_VERSION=$K3S_VERSION" >> "$GITHUB_ENV"
+echo "RANCHER_HELM_REPO_URL=$RANCHER_HELM_REPO_URL" >> "$GITHUB_ENV"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,29 +25,15 @@ env:
   KUBECONFIG_PATH: ${{ github.workspace }}/kubeconfig.yaml
 
 jobs:
-  load-rancher-branches-metadata:
+  e2e:
     runs-on: ubuntu-latest
-    outputs:
-      RANCHER_HELM_REPO_URL: ${{ steps.extract-metadata.outputs.RANCHER_HELM_REPO_URL }}
-      K3S_VERSION: ${{ steps.extract-metadata.outputs.K3S_VERSION }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
 
       - name: Load Rancher branches metadata
-        id: extract-metadata
         run: ./.github/scripts/load-rancher-branches-metadata.sh ${{ env.RANCHER_BRANCHES_METADATA_URL }} ${{ env.RANCHER_DEFAULT_BRANCH }}
-  e2e:
-    needs: load-rancher-branches-metadata
-    runs-on: ubuntu-latest
-    env:
-      RANCHER_HELM_REPO_URL: ${{ needs.load-rancher-branches-metadata.outputs.RANCHER_HELM_REPO_URL }}
-      K3S_VERSION: ${{ needs.load-rancher-branches-metadata.outputs.K3S_VERSION }}
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          fetch-depth: 1
 
       - name: Setup Node env
         uses: ./.github/actions/setup

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,13 +10,13 @@ on:
       - 'release-*'
 
 env:
-  RANCHER_VERSION: head
-  # The chart channel and k3s version this suite is validated against. The install script
-  # defaults both to `latest`; they are pinned here so CI stays on a known-good combination.
-  RANCHER_CHART_CHANNEL: release-2.15
-  K3S_VERSION: v1.36.1+k3s1
+  RANCHER_DEFAULT_VERSION: head
+  # The Rancher Helm repo URL and k3s version are fetched dynamically from the Rancher dashboard
+  # branches-metadata.json for the master branch to ensure consistency.
+  RANCHER_BRANCHES_METADATA_URL: https://raw.githubusercontent.com/rancher/dashboard/master/branches-metadata.json
+  RANCHER_DEFAULT_BRANCH: master
   # Rancher is installed via Helm on k3s and serves its own (stock) dashboard through the
-  # Traefik ingress over TLS. The rancher-ai-ui extension is developer-loaded into it at test
+  # Traefik ingress over TLS. the rancher-ai-ui extension is developer-loaded into it at test
   # time from a local catalog server (serve-pkgs), same-origin - no yarn dev proxy.
   CATTLE_SERVER_URL: https://127.0.0.1.sslip.io
   TEST_BASE_URL: https://127.0.0.1.sslip.io/dashboard
@@ -25,8 +25,25 @@ env:
   KUBECONFIG_PATH: ${{ github.workspace }}/kubeconfig.yaml
 
 jobs:
-  e2e:
+  load-rancher-branches-metadata:
     runs-on: ubuntu-latest
+    outputs:
+      RANCHER_HELM_REPO_URL: ${{ steps.extract-metadata.outputs.RANCHER_HELM_REPO_URL }}
+      K3S_VERSION: ${{ steps.extract-metadata.outputs.K3S_VERSION }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 1
+
+      - name: Load Rancher branches metadata
+        id: extract-metadata
+        run: ./.github/scripts/load-rancher-branches-metadata.sh ${{ env.RANCHER_BRANCHES_METADATA_URL }} ${{ env.RANCHER_DEFAULT_BRANCH }}
+  e2e:
+    needs: load-rancher-branches-metadata
+    runs-on: ubuntu-latest
+    env:
+      RANCHER_HELM_REPO_URL: ${{ needs.load-rancher-branches-metadata.outputs.RANCHER_HELM_REPO_URL }}
+      K3S_VERSION: ${{ needs.load-rancher-branches-metadata.outputs.K3S_VERSION }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -42,7 +59,7 @@ jobs:
         run: .github/scripts/start-extension-server.sh ${{ env.EXTENSION_SERVER_PORT }}
 
       - name: Start Rancher
-        run: .github/scripts/install-rancher-helm.sh ${{ env.RANCHER_VERSION }} ${{ env.CATTLE_SERVER_URL }} ${{ env.CATTLE_BOOTSTRAP_PASSWORD }} ${{ env.RANCHER_CHART_CHANNEL }} ${{ env.K3S_VERSION }}
+        run: .github/scripts/install-rancher-helm.sh ${{ env.RANCHER_DEFAULT_VERSION }} ${{ env.CATTLE_SERVER_URL }} ${{ env.CATTLE_BOOTSTRAP_PASSWORD }} ${{ env.RANCHER_HELM_REPO_URL }} ${{ env.K3S_VERSION }}
 
       - name: Deploy Rancher AI charts
         run: .github/scripts/deploy-rancher-ai.sh ${{ env.KUBECONFIG_PATH }}


### PR DESCRIPTION
We are now fetching the Rancher Helm chart URL and k3s from `branches-metadata.json` flle from `rancher/dashboard` repo.

The `load-rancher-branches-metadata` fails and blocks the e2e tests when:

- the metadata file name changes
- the values are not found where they are supposed to be in the file structure
- the values are empty or null
